### PR TITLE
fix misconfigured path to the templates db

### DIFF
--- a/src/alphafold3/data/templates.py
+++ b/src/alphafold3/data/templates.py
@@ -870,7 +870,7 @@ def run_hmmsearch_with_a3m(
   searcher = hmmsearch.Hmmsearch(
       binary_path=hmmsearch_config.hmmsearch_binary_path,
       hmmbuild_binary_path=hmmsearch_config.hmmbuild_binary_path,
-      database_path=_resolve_path(database_path),
+      database_path=database_path,
       e_value=hmmsearch_config.e_value,
       inc_e=hmmsearch_config.inc_e,
       dom_e=hmmsearch_config.dom_e,


### PR DESCRIPTION
fixes #26 so `hmmsearch` can proceed:

```
I1113 09:18:38.635883 140015615063616 subprocess_utils.py:68] Launching subprocess "/hmmer/bin/hmmsearch --noali --cpu 8 --F1 0.1 --F2 0.1 --F3 0.1 -E 100 --incE 100 --domE 100 --incdomE 100 -A /tmp/tmp_lkirt4p/output.sto /tmp/tmp_lkirt4p/query.hmm databases/pdb_seqres_2022_09_28.fasta"
I1113 09:18:44.688891 140015615063616 subprocess_utils.py:97] Finished Hmmsearch in 6.053 seconds
```