### PR TITLE
zlib compatibility for libcifpp

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM nvidia/cuda:12.6.0-base-ubuntu22.04
 # git is required for pyproject.toml toolchain's use of CMakeLists.txt.
 RUN apt update --quiet \
     && apt install --yes --quiet software-properties-common \
-    && apt install --yes --quiet git wget
+    && apt install --yes --quiet git wget zlib1g zlib1g-dev 
 
 # Get apt repository of specific Python versions. Then install Python. Tell APT
 # this isn't an interactive TTY to avoid timezone prompt when installing.


### PR DESCRIPTION
I failed to use docker to install alphafold3 in ubuntu2204 directly,so I use conda to do the cmds manually.

When I use `pip install . --no-deps --verbose`, cmake fails to find zlib for libcifpp.It `Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)`.

I use `conda install zlib` but it does not work.

Then I use apt to install:`sudo apt install zlib1g zlib1g-dev` and it works.

I add zlib1g,zlib1g-dev in dockerfile and the docker container also success.