### PR TITLE
fix type casting error in Apple Clang

### DIFF
--- a/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc
+++ b/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc
@@ -395,8 +395,9 @@ std::pair<py::object, MmcifLayout> MmcifFilter(  //
 
     if (layout.num_models() > 1) {
       keep_indices->reserve(layout.num_models() * new_num_atoms);
-      std::size_t* start = &(*keep_indices->begin());
-      std::size_t num_atom = keep_indices->size();
+      std::vector<std::size_t> indices(keep_indices->begin(), keep_indices->end());
+      std::size_t* start = indices.data();
+      std::size_t num_atom = indices.size();
       // Copy first model indices into all model indices offsetting each copy.
       for (std::size_t i = 1; i < layout.num_models(); ++i) {
         std::size_t offset = i * layout.num_atoms();


### PR DESCRIPTION
I've found a build error of alphafold3 on macOS with python3.11.

```bash
# install python3.11 using Homebrew
brew install python@3.11

git clone https://github.com/google-deepmind/alphafold3.git
cd alphafold3
python3.11 -m venv .venv
# activate virtual environment for alphafold3
. .venv/bin/activate

.venv/bin/python3.11 -m pip install absl-py==2.1.0 chex==0.1.87 dm-haiku==0.0.13 dm-tree==0.1.8 filelock==3.16.1 jax==0.4.34 jaxlib==0.4.34 jaxtyping==0.2.34 jmp==0.0.4 ml-dtypes==0.5.0 numpy==2.1.3 opt-einsum==3.4.0 pillow==11.0.0 rdkit==2024.3.5 scipy==1.14.1 tabulate==0.9.0 toolz==1.0.0 tqdm==4.67.0 typeguard==2.13.3 typing-extensions==4.12.2 zstandard==0.23.0
```

After this, I tried to install alphafold3 with pip, but a build error occurred:

```bash
$ python3.11 -m pip install --no-deps .
Processing /Users/YoshitakaM/Desktop/alphafold3
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: alphafold3

...
...

      [48/235] Building CXX object _deps/abseil-cpp-build/absl/crc/CMakeFiles/absl_crc32c.dir/internal/crc_non_temporal_memcpy.cc.o
      [49/235] Building CXX object CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc.o
      FAILED: CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc.o
      /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DCACHE_DIR=\"/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/wheel/platlib/var/cache/libcifpp\" -DDATA_DIR=\"/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/wheel/platlib/share/libcifpp\" -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -DVERSION_INFO=3.0.0 -Dcpp_EXPORTS -I/Users/YoshitakaM/Desktop/alphafold3/src -I/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/build/_deps/abseil-cpp-src -I/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/build/_deps/pybind11_abseil-src -I/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/build/_deps/dssp-src/libdssp/include -I/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/build/_deps/dssp-src/libdssp/../src -I/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/build/_deps/cifpp-src/include -isystem /opt/homebrew/Cellar/python@3.11/3.11.10/Frameworks/Python.framework/Versions/3.11/include/python3.11 -isystem /var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/tmplt1pusbs/build/_deps/pybind11-src/include -isystem /private/var/folders/lq/522p0ddd5435m5qyyn4hwtrh0000gn/T/pip-build-env-abujcfbk/overlay/lib/python3.11/site-packages/numpy/_core/include -O3 -DNDEBUG -std=gnu++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk -mmacosx-version-min=14.7 -fPIC -fvisibility=hidden -flto -MD -MT CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc.o -MF CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc.o.d -o CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc.o -c /Users/YoshitakaM/Desktop/alphafold3/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc
      /Users/YoshitakaM/Desktop/alphafold3/src/alphafold3/structure/cpp/mmcif_utils_pybind.cc:398:20: error: cannot initialize a variable of type 'std::size_t *' (aka 'unsigned long *') with an rvalue of type 'unsigned long long *'
        398 |       std::size_t* start = &(*keep_indices->begin());
            |                    ^       ~~~~~~~~~~~~~~~~~~~~~~~~~
      1 error generated.
      [50/235] Building CXX object CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/mmcif_layout_pybind.cc.o
      [51/235] Building CXX object _deps/abseil-cpp-build/absl/debugging/CMakeFiles/absl_examine_stack.dir/internal/examine_stack.cc.o
      [52/235] Building CXX object _deps/abseil-cpp-build/absl/debugging/CMakeFiles/absl_symbolize.dir/symbolize.cc.o
      [53/235] Building CXX object _deps/abseil-cpp-build/absl/crc/CMakeFiles/absl_crc_cord_state.dir/internal/crc_cord_state.cc.o
      [54/235] Building CXX object _deps/abseil-cpp-build/absl/hash/CMakeFiles/absl_city.dir/internal/city.cc.o
      [55/235] Building CXX object _deps/abseil-cpp-build/absl/debugging/CMakeFiles/absl_demangle_internal.dir/internal/demangle.cc.o
      [56/235] Building CXX object _deps/abseil-cpp-build/absl/hash/CMakeFiles/absl_low_level_hash.dir/internal/low_level_hash.cc.o
      [57/235] Building CXX object _deps/abseil-cpp-build/absl/hash/CMakeFiles/absl_hash.dir/internal/hash.cc.o
      [58/235] Building CXX object _deps/abseil-cpp-build/absl/crc/CMakeFiles/absl_crc_internal.dir/internal/crc_x86_arm_combined.cc.o
      [59/235] Building CXX object _deps/abseil-cpp-build/absl/log/CMakeFiles/absl_log_internal_check_op.dir/internal/check_op.cc.o
      [60/235] Building CXX object CMakeFiles/cpp.dir/src/alphafold3/structure/cpp/string_array_pybind.cc.o
      [61/235] Building CXX object CMakeFiles/cpp.dir/src/alphafold3/parsers/cpp/cif_dict_pybind.cc.o
      ninja: build stopped: subcommand failed.
      
      *** CMake build failed
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for alphafold3
Failed to build alphafold3
```

This error occurs on Apple M3 Pro & macOS Sonoma 14.7.1. My Pull Request fixed this issue.
Of course I understand that alphafold3 does not work on macOS because jax-triton requires NVIDIA GPU. However, I hope this fix helps for simple test on macOS.