### PR TITLE
Update GPU compute capability check to reflect devices that are known to work correctly.

### DIFF
--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -628,10 +628,16 @@ def main(_):
   if _RUN_INFERENCE.value:
     # Fail early on incompatible devices, but only if we're running inference.
     gpu_devices = jax.local_devices(backend='gpu')
-    if gpu_devices and float(gpu_devices[0].compute_capability) < 8.0:
+    compute_capability = float(gpu_devices[0].compute_capability)
+    if gpu_devices and (
+      compute_capability < 6.0
+      or (compute_capability >= 7.0 and compute_capability < 8.0)
+    ):
       raise ValueError(
           'There are currently known unresolved numerical issues with using'
-          ' devices with compute capability less than 8.0. See '
+          ' devices with compute capability 7.x. The code has not been tested'
+          ' with compute capability < 6.0. The code has been confirmed to work'
+          ' with compute capability 6.x and 8.x. See '
           ' https://github.com/google-deepmind/alphafold3/issues/59 for'
           ' tracking.'
       )


### PR DESCRIPTION
### Changes

- Allow running alphafold3 with compute capability 6.x
- New range for `raise ValueError` : <6.0 and 7.x
- Update error message to clarify working compute capability (6.x and 8.x)

### Testing
Tested that it does not `raise ValueError` on the following GPUs:
- [x] P100 (6.x)
- [x] A100-80 (8.x)
- [x] A5000 (8x)

Tested that it does `raise ValueError` on the following GPUs:
- [x] V100 (7.x)
- [x] T4 (7.x)

see #59 for details