### PR TITLE
Dockerfile refinements and add Apptainer definition

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,50 +8,115 @@
 # if received directly from Google. Use is subject to terms of use available at
 # https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
 
-FROM nvidia/cuda:12.6.0-base-ubuntu22.04
+FROM nvidia/cuda:12.6.0-base-ubuntu22.04 AS hmmer_build
 
-# Some RUN statements are combined together to make Docker build run faster.
+ARG DEBIAN_FRONTEND=noninteractive
+ARG HMMER_VERSION=3.4
+
+# gcc, g++, make are required for compiling hmmer
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        wget \
+        gcc \
+        g++ \
+        make \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build HMMER
+RUN mkdir /hmmer_build /hmmer \
+    && wget http://eddylab.org/software/hmmer/hmmer-${HMMER_VERSION}.tar.gz --directory-prefix /hmmer_build \
+    && cd /hmmer_build && tar zxf hmmer-*.tar.gz && rm hmmer-*.tar.gz \
+    && cd ./hmmer-* \
+    && ./configure --prefix /hmmer \
+    && make -j8 \
+    && make install \
+    && cd ./easel && make install \
+    && rm -R /hmmer_build
+
+
+FROM nvidia/cuda:12.6.0-base-ubuntu22.04 AS alphafold_build
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG ALPHAFOLD_VERSION=3.0.0
+
 # Get latest package listing, install software-properties-common, git, wget,
 # compilers and libraries.
 # git is required for pyproject.toml toolchain's use of CMakeLists.txt.
-# gcc, g++, make are required for compiling hmmer and AlphaFold 3 libaries.
+# gcc, g++, make are required for compiling AlphaFold 3 libaries.
 # zlib is a required dependency of AlphaFold 3.
-RUN apt update --quiet \
-    && apt install --yes --quiet software-properties-common \
-    && apt install --yes --quiet git wget gcc g++ make zlib1g-dev zstd
+# Use deadsnakes/ppa apt repository to install specific Python versions
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install --no-install-recommends -y \
+        git \
+        wget \
+        gcc \
+        g++ \
+        make \
+        zlib1g-dev \
+        zstd \
+        python3.11 \
+        python3-pip \
+        python3.11-venv \
+        python3.11-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Get apt repository of specific Python versions. Then install Python. Tell APT
-# this isn't an interactive TTY to avoid timezone prompt when installing.
-RUN add-apt-repository ppa:deadsnakes/ppa \
-    && DEBIAN_FRONTEND=noninteractive apt install --yes --quiet python3.11 python3-pip python3.11-venv python3.11-dev
+# Create Python 3.11 virtual environment for the AlphaFold build
 RUN python3.11 -m venv /alphafold3_venv
-ENV PATH="/hmmer/bin:/alphafold3_venv/bin:$PATH"
+
 # Update pip to the latest version. Not necessary in Docker, but good to do when
 # this is used as a recipe for local installation since we rely on new pip
 # features for secure installs.
-RUN pip3 install --upgrade pip
+RUN /alphafold3_venv/bin/pip3 install --no-cache-dir --upgrade pip
 
-# Install HMMER. Do so before copying the source code, so that docker can cache
-# the image layer containing HMMER.
-RUN mkdir /hmmer_build /hmmer ; \
-    wget http://eddylab.org/software/hmmer/hmmer-3.4.tar.gz --directory-prefix /hmmer_build ; \
-    (cd /hmmer_build && tar zxf hmmer-3.4.tar.gz && rm hmmer-3.4.tar.gz) ; \
-    (cd /hmmer_build/hmmer-3.4 && ./configure --prefix /hmmer) ; \
-    (cd /hmmer_build/hmmer-3.4 && make -j8) ; \
-    (cd /hmmer_build/hmmer-3.4 && make install) ; \
-    (cd /hmmer_build/hmmer-3.4/easel && make install) ; \
-    rm -R /hmmer_build
-
-# Copy the AlphaFold 3 source code from the local machine to the container and
+# Add the AlphaFold 3 source code from the local machine to the container and
 # set the working directory to there.
-COPY . /app/alphafold
+# COPY . /app/alphafold
+
+# Add the AlphaFold 3 source code from GitHub to the image and
+# set the working directory to there
+ADD https://github.com/google-deepmind/alphafold3.git#v${ALPHAFOLD_VERSION} /app/alphafold
+
 WORKDIR /app/alphafold
 
-# Install the Python dependencies AlphaFold 3 needs.
-RUN pip3 install -r dev-requirements.txt
-RUN pip3 install --no-deps .
-# Build chemical components database (this binary was installed by pip).
-RUN build_data
+# Install the Python dependencies AlphaFold 3 needs and build AlphaFold itself.
+RUN /alphafold3_venv/bin/pip3 install --no-cache-dir -r dev-requirements.txt \
+    && /alphafold3_venv/bin/pip3 install --no-cache-dir --no-deps --verbose .
+
+    # Build chemical components database (this binary was installed by pip).
+RUN /alphafold3_venv/bin/build_data
+
+# Remove build-related content from the AlphaFold directory, ready for copy in the
+# "final" stage
+RUN [ "/bin/bash", \
+    "-c", \
+    "rm -rf /app/alphafold/{CMakeLists.txt,dev-requirements.txt,docker,pyproject.toml,requirements.txt,src}" ]
+
+
+FROM nvidia/cuda:12.6.0-base-ubuntu22.04 AS final
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY --from=hmmer_build /hmmer /hmmer
+COPY --from=alphafold_build /alphafold3_venv /alphafold3_venv
+COPY --from=alphafold_build /app/alphafold /app/alphafold
+
+# Package installs without dev or build related requirements
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install --no-install-recommends -y \
+        git \
+        wget \
+        zlib1g \
+        zstd \
+        python3.11 \
+        python3-pip \
+        python3.11-venv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # To work around a known XLA issue causing the compilation time to greatly
 # increase, the following environment variable setting XLA flags must be enabled
@@ -61,4 +126,8 @@ ENV XLA_FLAGS="--xla_gpu_enable_triton_gemm=false"
 ENV XLA_PYTHON_CLIENT_PREALLOCATE=true
 ENV XLA_CLIENT_MEM_FRACTION=0.95
 
-CMD ["python3", "run_alphafold.py"]
+ENV PATH="/hmmer/bin:/alphafold3_venv/bin:${PATH}"
+
+WORKDIR /app/alphafold
+
+CMD ["python3", "run_alphafold.py", "--help"]

--- a/docker/alphafold3.def
+++ b/docker/alphafold3.def
@@ -1,0 +1,140 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under CC BY-NC-SA 4.0. To view a copy of
+# this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these
+# if received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
+
+# Script modified from Dockerfile (https://github.com/google-deepmind/alphafold3/blob/cdbcf41b71235ec33338edef1f80e03fb0c6bae4/docker/Dockerfile)
+# by BEAR Software team at the University of Birmingham, UK
+
+Bootstrap: docker
+From: nvidia/cuda:12.6.0-base-ubuntu22.04
+Stage: hmmer_build
+
+%arguments
+    hmmer_version=3.4
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update && apt-get install --no-install-recommends -y \
+            git \
+            wget \
+            gcc \
+            g++ \
+            make \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+    # Build HMMER
+    mkdir /hmmer_build /hmmer
+    wget http://eddylab.org/software/hmmer/hmmer-{{ hmmer_version }}.tar.gz --directory-prefix /hmmer_build
+    cd /hmmer_build && tar zxf hmmer-*.tar.gz && rm hmmer-*.tar.gz
+    cd ./hmmer-*
+    ./configure --prefix /hmmer
+    make -j8
+    make install
+    cd ./easel && make install
+    rm -R /hmmer_build
+
+####################
+
+Bootstrap: docker
+From: nvidia/cuda:12.6.0-base-ubuntu22.04
+Stage: alphafold3_build
+
+%arguments
+    alphafold_version=3.0.0
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update && apt-get install --no-install-recommends -y \
+            software-properties-common \
+        && add-apt-repository ppa:deadsnakes/ppa \
+        && apt-get update && apt-get install --no-install-recommends -y \
+            git \
+            wget \
+            gcc \
+            g++ \
+            make \
+            zlib1g-dev \
+            zstd \
+            python3.11 \
+            python3-pip \
+            python3.11-venv \
+            python3.11-dev \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+    # Create Python 3.11 virtual environment for the AlphaFold build
+    python3.11 -m venv /alphafold3_venv
+
+    # Update pip to the latest version
+    /alphafold3_venv/bin/pip3 install --upgrade pip
+    
+    # Get AlphaFold 3 source code
+    mkdir -p /app
+    cd /tmp
+    wget https://github.com/google-deepmind/alphafold3/archive/refs/tags/v{{ alphafold_version }}.tar.gz
+    tar zxf *.tar.gz
+    mv /tmp/alphafold3-* "/app/alphafold"
+    rm -f *.tar.gz
+
+    cd "/app/alphafold"
+    # Install the Python dependencies AlphaFold 3 needs.
+    /alphafold3_venv/bin/pip3 install --no-cache-dir -r dev-requirements.txt
+    # Build AlphaFold 3.
+    /alphafold3_venv/bin/pip3 install --no-cache-dir --no-deps --verbose .
+    # Build chemical components database (this binary was installed by pip).
+    /alphafold3_venv/bin/build_data
+
+    # Remove build-only content from AlphaFold repo directory
+    /bin/bash -c "rm -rf /app/alphafold/{dev-requirements.txt,docker,pyproject.toml,requirements.txt,src,CMakeLists.txt}"
+
+####################
+
+Bootstrap: docker
+From: nvidia/cuda:12.6.0-base-ubuntu22.04
+Stage: final
+
+%files from hmmer_build
+    /hmmer /hmmer
+
+%files from alphafold3_build
+    /alphafold3_venv /alphafold3_venv
+    /app/alphafold /app/alphafold
+
+%environment
+    export PATH="/hmmer/bin:/alphafold3_venv/bin:${PATH}"
+    # To work around a known XLA issue causing the compilation time to greatly
+    # increase, the following environment variable setting XLA flags must be enabled
+    # when running AlphaFold 3:
+    export XLA_FLAGS="--xla_gpu_enable_triton_gemm=false"
+    # Memory settings used for folding up to 5,120 tokens on A100 80 GB.
+    export XLA_PYTHON_CLIENT_PREALLOCATE=true
+    export XLA_CLIENT_MEM_FRACTION=0.95
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update && apt-get install --no-install-recommends -y \
+            software-properties-common \
+        && add-apt-repository ppa:deadsnakes/ppa \
+        && apt-get update && apt-get install --no-install-recommends -y \
+            git \
+            wget \
+            zlib1g \
+            zstd \
+            python3.11 \
+            python3-pip \
+            python3.11-venv \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+%runscript
+    exec python3 /app/alphafold/run_alphafold.py "$@"


### PR DESCRIPTION
Brief overview of PR changes

Dockerfile:

- Use a multi-stage build to minimise the layers and size of the final image. Also allows targeting of dev pkg installs.
- Replace `apt` (primarily designed for interactive use) with `apt-get`

Apptainer definition file:

- Broadly replicates Dockerfile process, also using a multi-stage build.


Issues:

- `triton` dependency is only availble as compiled x86_64 wheel on pypi.org so Arm-based builds aren't possible without moving the triton install to a separate compile step.