### PR TITLE
fix the nan  bug of cpu inference

### DIFF
--- a/src/alphafold3/model/network/diffusion_head.py
+++ b/src/alphafold3/model/network/diffusion_head.py
@@ -339,6 +339,7 @@ def sample(
     t_hat = noise_level_prev * (1 + gamma)
 
     noise_scale = config.noise_scale * jnp.sqrt(t_hat**2 - noise_level_prev**2)
+    noise_scale = jnp.nan_to_num(noise_scale, nan=0.0, posinf=0.0, neginf=0.0)
     noise = noise_scale * jax.random.normal(key_noise, positions.shape)
     positions_noisy = positions + noise
 


### PR DESCRIPTION
fixed the bug of cpu inference #273 .I noticed that after sqrt, there were some Nans in noise_scale, which caused errors in subsequent calculations.nan to 0 could fix this
