### PR TITLE
Suppress output from Jackhmmer seq limit check

### DIFF
--- a/src/alphafold3/data/tools/subprocess_utils.py
+++ b/src/alphafold3/data/tools/subprocess_utils.py
@@ -39,7 +39,7 @@ def check_binary_exists(path: str, name: str) -> None:
 def jackhmmer_seq_limit_supported(jackhmmer_path: str) -> bool:
   """Checks if Jackhmmer supports the --seq-limit flag."""
   try:
-    subprocess.run([jackhmmer_path, '-h', '--seq_limit', '1'], check=True)
+    subprocess.run([jackhmmer_path, '-h', '--seq_limit', '1'], capture_output=True, check=True)
   except subprocess.CalledProcessError:
     return False
   return True


### PR DESCRIPTION
The current implementation of `jackhmmer_seq_limit_supported` prints out the output of the command (and thus many copies of the full usage information of `jackhmmer`) to the terminal. This commit sets `capture_output` to `True`, meaning it'll be stored in the return dictionary of `subprocess.run()` rather than printed to the terminal.