### PR TITLE
chore: upgrade GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,9 @@ jobs:
             python-version: '3.11'
             os: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
## Summary
Upgrade GitHub Actions to Node 24-compatible versions in preparation for the Node 20 deprecation.

## Changes
- Update `actions/checkout` from v4 to **v6**
- Update `actions/setup-python` from v5 to **v6**

## Why
Node 20 will reach end-of-life (EOL) in April 2026. GitHub has announced they will migrate all actions to run on Node 24 by default starting March 2026.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Requirements
Both v6 releases require runner version v2.327.1 or later, which is standard for GitHub-hosted runners like `ubuntu-latest`.