### PR TITLE
Added JAAG community tool to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,3 +259,20 @@ available with reference to the following:
     See the Supplementary Information of the
     [AlphaFold 3 paper](https://nature.com/articles/s41586-024-07487-w) for
     details.
+
+
+## Community Tools
+
+### JAAG — JSON input file Assembler for AlphaFold 3 (with Glycan Integration)
+
+JAAG is a lightweight, web-based GUI tool that helps generate AlphaFold 3 input
+`.json` files with integrated glycan support. It automates the creation of correct
+glycan syntax (including bondedAtomPairs + CCD), reducing manual errors when
+preparing glycoprotein or glycan–protein systems.
+
+- Web app: https://biofgreat.org/JAAG
+- Source code: https://github.com/chinchc/JAAG
+- Preprint: https://www.biorxiv.org/content/10.1101/2025.10.08.681238v1
+
+Note: JAAG is compatible with standalone AlphaFold 3, but not with the public AF3 server.
+


### PR DESCRIPTION
This PR adds a short documentation section for the JAAG community GUI tool,
which helps generate AlphaFold 3 JSON input files with glycan integration.

type of change : Documentation-only change.

Related to issue #537.
