### PR TITLE
Support dynamic version for dev and releases.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "alphafold3"
-version = "3.0.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -51,6 +51,7 @@ sdist.include = [
     "WEIGHTS_PROHIBITED_USE_POLICY.md",
     "WEIGHTS_TERMS_OF_USE.md",
 ]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64"


### PR DESCRIPTION
When installing from `HEAD`, this would allow one to have traceable reproducibility.
A local wheel built today from a fresh clone, would be tagged `alphafold3-3.0.2.dev113+gebfe70a27.d20260206-cp313-cp313-linux_x86_64.whl`.

The version is incremented from the current tag.
A `dev` release suffix which show that `113` commits have been made since.
A local version `+gebfe70a27.d20260206` which means : 
- `gebfe70a27` (g+short commit)
- `d20260206` (d+date)

Hence it is easy to know which build/commit a user used as it is described in the file name.

Ref: 
- https://scikit-build-core.readthedocs.io/en/latest/configuration/dynamic.html
- https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme