### PR TITLE
Fix seed handling crash when using --num_seeds with multiple input seeds Resolves issue #622.

### DIFF
--- a/src/alphafold3/common/folding_input.py
+++ b/src/alphafold3/common/folding_input.py
@@ -1482,12 +1482,11 @@ class Input:
     """Returns a copy of the input with num_seeds rng seeds."""
     if num_seeds <= 1:
       raise ValueError('Number of seeds must be greater than 1.')
-    if len(self.rng_seeds) != 1:
-      raise ValueError('Input must have one rng seed to set multiple seeds.')
 
+    base_seed = self.rng_seeds[0]
     return dataclasses.replace(
         self,
-        rng_seeds=list(range(self.rng_seeds[0], self.rng_seeds[0] + num_seeds)),
+        rng_seeds=list(range(base_seed, base_seed + num_seeds)),
     )
 
 

--- a/src/alphafold3/common/folding_input_seed_test.py
+++ b/src/alphafold3/common/folding_input_seed_test.py
@@ -1,0 +1,59 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock necessary modules to avoid import errors
+sys.modules['alphafold3.cpp'] = MagicMock()
+sys.modules['alphafold3.cpp.cif_dict'] = MagicMock()
+sys.modules['alphafold3.cpp.cif_dict'].parse_multi_data_cif.return_value = {}
+sys.modules['rdkit'] = MagicMock()
+sys.modules['rdkit.Chem'] = MagicMock()
+sys.modules['zstandard'] = MagicMock()
+sys.modules['jax'] = MagicMock()
+sys.modules['jax.numpy'] = MagicMock()
+sys.modules['tokamax'] = MagicMock()
+
+import unittest
+from alphafold3.common import folding_input
+
+class FoldingInputSeedTest(unittest.TestCase):
+
+  def test_with_multiple_seeds_single_seed(self):
+    """Tests with_multiple_seeds when input has a single seed."""
+    test_input = folding_input.Input(
+        name='test',
+        chains=[],
+        rng_seeds=[1]
+    )
+    updated_input = test_input.with_multiple_seeds(5)
+    self.assertEqual(list(updated_input.rng_seeds), [1, 2, 3, 4, 5])
+
+  def test_with_multiple_seeds_multiple_seeds_override(self):
+    """Tests with_multiple_seeds when input already has multiple seeds (Issue #622)."""
+    test_input = folding_input.Input(
+        name='test',
+        chains=[],
+        rng_seeds=[10, 20, 30]
+    )
+    # This used to raise ValueError, now it should work and use the first seed as base.
+    updated_input = test_input.with_multiple_seeds(3)
+    self.assertEqual(list(updated_input.rng_seeds), [10, 11, 12])
+
+  def test_with_multiple_seeds_invalid_count(self):
+    """Tests that with_multiple_seeds raises ValueError for invalid seed counts."""
+    # We can't easily instantiate Input with full validation without more mocks,
+    # but we can try basic initialization for logic testing.
+    # Note: Input.__post_init__ might fail if we don't mock more things.
+    # Let's use a mock for Input if needed, but we want to test the real method.
+    
+    test_input = folding_input.Input(
+        name='test',
+        chains=[],
+        rng_seeds=[123]
+    )
+    with self.assertRaisesRegex(ValueError, 'Number of seeds must be greater than 1'):
+      test_input.with_multiple_seeds(1)
+    with self.assertRaisesRegex(ValueError, 'Number of seeds must be greater than 1'):
+      test_input.with_multiple_seeds(0)
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Problem
=====================

Resolves issue #622.

Currently, the Input::with_multiple_seeds method raises a ValueError
if the input object already contains more than one seed.

This causes a crash when:
- A user provides a JSON input containing multiple "modelSeeds"
- AND also specifies the --num_seeds command-line flag

The CLI flag attempts to re-initialize the seeds, triggering
the strict length check and resulting in a failure.


Solution
=====================

Modified:
src/alphafold3/common/folding_input.py

Updated the with_multiple_seeds method to allow overriding
an existing list of multiple seeds.

New behavior:
- The first seed in the existing list is treated as the base seed.
- The requested number of sequential seeds is generated
  starting from that base value.


Changes
=====================

1. Modified:
src/alphafold3/common/folding_input.py
- Removed the strict requirement:
  len(self.rng_seeds) == 1
- Enabled regeneration of seeds even if multiple seeds already exist.

2. Added:
src/alphafold3/common/folding_input_seed_test.py
- New unit tests covering:
  • Expansion from a single seed
  • Expansion from multiple seeds (fix for #622)
  • Validation of invalid seed counts


Verification Results
=====================

Ran unit tests with mocked dependencies to verify logic.

Output:
Ran 3 tests in 0.000s
OK
