### PR TITLE
Fix fetch_databases.sh to exit on missing required commands

### DIFF
--- a/fetch_databases.sh
+++ b/fetch_databases.sh
@@ -13,11 +13,17 @@ set -euo pipefail
 
 readonly db_dir=${1:-$HOME/public_databases}
 
+missing_cmds=()
 for cmd in wget tar zstd ; do
   if ! command -v "${cmd}" > /dev/null 2>&1; then
-    echo "${cmd} is not installed. Please install it."
+    echo "Error: Required command '${cmd}' is not installed." >&2
+    missing_cmds+=("${cmd}")
   fi
 done
+if [[ ${#missing_cmds[@]} -gt 0 ]]; then
+  echo "Aborting: missing required commands: ${missing_cmds[*]}" >&2
+  exit 1
+fi
 
 echo "Fetching databases to ${db_dir}"
 mkdir -p "${db_dir}"


### PR DESCRIPTION
## Summary
Fixes a bug in fetch_databases.sh where the dependency check for wget, 	ar, and zstd prints a warning message but **does not exit the script**. This causes the script to proceed and fail with confusing errors during actual download/extraction steps.

## Root Cause
The original code (lines 16-20) checks for required commands but only prints a message without exiting. With set -euo pipefail at the top of the script, the script would eventually fail when trying to use the missing tool, but the error message would be about the download/extraction failure rather than the missing dependency.

## Changes
- **fetch_databases.sh**: Collects all missing commands into an array, reports each to stderr, and exits with code 1 before attempting any downloads.

## Testing
- Verified script syntax
- Backward compatible: no behavior change when all dependencies are present

cc @Augustin-Zidek