### PR TITLE
fix glycan O1 leaving-atom cleanup for standalone glycans

### DIFF
--- a/src/alphafold3/model/atom_layout/atom_layout.py
+++ b/src/alphafold3/model/atom_layout/atom_layout.py
@@ -677,7 +677,7 @@ def get_link_drop_atoms(
         *chemical_component_sets.GLYCAN_OTHER_LIGANDS,
         *chemical_component_sets.GLYCAN_LINKING_LIGANDS,
     }:
-      if 'O1' not in bonded_atoms:
+      if bonded_atoms and 'O1' not in bonded_atoms:
         drop_atoms.update({'O1'})
   return drop_atoms
 

--- a/src/alphafold3/model/pipeline/structure_cleaning.py
+++ b/src/alphafold3/model/pipeline/structure_cleaning.py
@@ -166,9 +166,13 @@ def clean_structure(
         *chemical_component_sets.GLYCAN_OTHER_LIGANDS,
         *chemical_component_sets.GLYCAN_LINKING_LIGANDS,
     }
-    # If only glycan ligands and no O1 atoms, we can do parallel drop.
+    # If only glycan ligands and no O1 atoms, we can do parallel drop. If there are no glycan bonds at all, keep O1.
+    has_any_glycan_bond = bool(
+        ligand_ligand_bonds.atom_name.size or polymer_ligand_bonds.atom_name.size
+    )
     if (
         only_glycan_ligands_for_leaving_atoms
+        and has_any_glycan_bond
         and (not (ligand_ligand_bonds.atom_name == 'O1').any())
         and (not (polymer_ligand_bonds.atom_name == 'O1').any())
     ):


### PR DESCRIPTION
## Summary
Currently, glycan `O1` can be removed during leaving-atom cleanup even when no glycan bond context exists. This incorrectly affects standalone glycans, where `O1` should be preserved. This PR makes the cleanup logic bond-aware, so `O1` is only dropped when glycan bond information indicates that it should be treated as a leaving atom.

The `6MJ` ligand in `7zdy` is one example where this occurs, the same issue applies more generally to standalone glycans containing `O1`. The image below shows the effect of the change, with the structure before the fix on the left (red) and after the fix on the right (green).

## Changes
- require glycan bond context before dropping glycan `O1`
- preserve `O1` on standalone glycans
- skip the fast-path `O1` removal when no glycan bonds are present

<img width="1195" height="468" alt="example" src="https://github.com/user-attachments/assets/6198f473-6dba-4895-a341-5f702ea86c68" />