### PR TITLE
Add example test JSON and current status note for two-letter atoms (Cl/Br) in SMILES ligands

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -14,6 +14,16 @@ https://github.com/google-deepmind/alphafold3/commit/4e4023c, AlphaFold 3
 handled incorrectly any two-letter atoms (e.g. Cl, Br) in ligands defined using
 SMILES strings.
 
+**Current status:**  
+This issue was resolved starting from commit 4e4023c (which standardized atom name assignment using a shared RDKit utility). Two-letter elements like Cl and Br in SMILES are now parsed and handled correctly on the main branch.
+
+To demonstrate and validate proper input for common drug-like molecules (halogens appear frequently in pharmaceuticals), a new example has been added:
+
+- File: `test_inputs/ligand_halogen_cl.json`  
+- SMILES: `CC(=O)Nc1ccc(Cl)cc1` (paracetamol analog with chlorine)
+
+This serves as a reference test case for users working with halogen-containing ligands.
+
 ## MSA discrepancy between AlphaFold 3 and AlphaFold Server
 
 ### The root cause of the problem

--- a/test_inputs/ligand_halogen_cl.json
+++ b/test_inputs/ligand_halogen_cl.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "test_ligand_with_chlorine",
+    "modelSeeds": [1],
+    "sequences": [
+      {
+        "protein": {
+          "sequence": "MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVIDGETCLLDILDTAGQEEYSAMRDQYMRTGEGFLCVFAINNTKSFEDIHHYREQIKRVKDSEDIPAVFHQILRA"
+        }
+      },
+      {
+        "ligand": {
+          "id": ["LIG"],
+          "smiles": "CC(=O)Nc1ccc(Cl)cc1",
+          "count": 1
+        }
+      }
+    ],
+    "dialect": "alphafold3",
+    "version": 1
+  }
+]


### PR DESCRIPTION
Hey team,
Just a small PR to tidy up the "Incorrect handling of two-letter atoms in SMILES ligands" bit in known_issues.md.
What I did:
Dropped in a tiny test input: test_inputs/ligand_halogen_cl.json — it's a super basic protein + ligand example using a SMILES with Cl (basically a paracetamol-ish molecule with chlorine) and added a short "Current status" note right after the existing text saying the issue got sorted after commit 4e4023c, and pointing to the new example file so people can see it actually works now.

Why bother?
The known issue page still reads like the bug might still be there, but it isn't anymore. Halogens (Cl, Br especially) show up all the time in real drug molecules, so I figured a quick note + concrete example would save someone some head-scratching later.
No code touched — just docs + one example JSON file. I double-checked the JSON against input.md and it looks good.
Quick note on AI: I used Grok (xAI) to help phrase the note and this description, but I went through everything line-by-line, edited it myself, and made sure it actually says what I mean.
If this looks off, or you'd prefer a Br example too, or want me to run/test anything specific — lemme know, happy to tweak!
Thanks for keeping AlphaFold 3 open and awesome — really really appreciate it!!
Best,
Sejuti