### PR TITLE
Replace ; with && in HMMER build in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,10 +51,10 @@ COPY docker/jackhmmer_seq_limit.patch /hmmer_build/
 RUN (cd /hmmer_build && patch -p0 < jackhmmer_seq_limit.patch)
 
 # Build HMMER.
-RUN (cd /hmmer_build/hmmer-3.4 && ./configure --prefix /hmmer) ; \
-    (cd /hmmer_build/hmmer-3.4 && make -j) ; \
-    (cd /hmmer_build/hmmer-3.4 && make install) ; \
-    (cd /hmmer_build/hmmer-3.4/easel && make install) ; \
+RUN (cd /hmmer_build/hmmer-3.4 && ./configure --prefix /hmmer) && \
+    (cd /hmmer_build/hmmer-3.4 && make -j) && \
+    (cd /hmmer_build/hmmer-3.4 && make install) && \
+    (cd /hmmer_build/hmmer-3.4/easel && make install) && \
     rm -R /hmmer_build
 
 # Copy the AlphaFold 3 source code from the local machine to the container and


### PR DESCRIPTION
As I discovered by accident today, if one of the steps of the HMMER build fails the installation continues due to the use of `;` rather than `&&` at the end of each sub-step in that step on the `Dockerfile`.