### PR TITLE
docs: document chain-internal ncAAs via userCCDPath and protein modifications

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -743,6 +743,43 @@ as it could cause issues in the mmCIF format.
 The newly defined ligand can then be used as a standard CCD ligand using its
 custom name, and bonds can be linked to it using its named atom scheme.
 
+### Using a user-provided CCD for a protein modification
+
+  `userCCD` and `userCCDPath` can also be used for chain-internal non-canonical amino acids, not only custom ligands.
+
+  In this case, the custom component is referenced from the protein `modifications` field using its CCD component ID:
+
+  ```json
+  {
+    "name": "protein_with_FSY",
+    "modelSeeds": [1],
+    "sequences": [
+      {
+        "protein": {
+          "id": "A",
+          "sequence": "MDQHQAFKEATELLEKMKTSSDEERVEYLRKAVRLFNLTSEGQQGELVGKFKEAGVLIRAVDLS",
+          "modifications": [
+            {"ptmType": "FSY", "ptmPosition": 30}
+          ],
+          "unpairedMsa": "",
+          "pairedMsa": "",
+          "templates": []
+        }
+      }
+    ],
+    "version": 4
+  }
+
+  In the example above, residue 30 is replaced by the custom component FSY.
+
+  - ptmType must match the component ID defined in the user-provided CCD.
+  - The user-provided CCD should describe an appropriate peptide-linking polymer component rather than a non-polymer
+    ligand.
+  - The CCD should include the expected backbone atoms and bond graph for a chain-internal residue.
+
+  This workflow is useful for modeling chain-internal non-canonical amino acids. By contrast, external covalent ligands
+  should generally be modeled as ligand entities plus bondedAtomPairs.
+
 ### Conformer Generation
 
 The data pipeline attempts to generate a conformer for ligands using RDKit. The


### PR DESCRIPTION
 ## Summary

  This PR adds a short documentation example for using a user-provided CCD component as a chain-internal non-canonical
  amino acid via `protein.modifications`.

  The code path already supports this workflow, but `docs/input.md` currently documents protein modifications and user-
  provided CCDs mainly as separate concepts, and the user-provided CCD section is currently framed around custom
  ligands.

  This patch adds:

  - a short subsection under `User-provided CCD`
  - a minimal JSON example using `userCCDPath + protein.modifications`
  - a brief note distinguishing chain-internal ncAAs from external covalent ligands modeled with ligand entities plus
  `bondedAtomPairs`

  ## Why

  Without an explicit example, it is easy to assume that `userCCDPath` is only intended for ligands, or that chain-
  internal ncAAs should be modeled as ligands rather than polymer modifications.

  ## Testing

  Documentation-only change.

  I also manually validated this workflow on a local AlphaFold 3 installation by running inference with custom peptide-
  linking components referenced through `protein.modifications` and supplied through `userCCDPath`.

  ## AI usage disclosure

  This PR text and the initial draft wording were prepared with AI assistance, then manually reviewed and edited before
  submission.