### PR TITLE
Feature: use chain IDs as keys in summary_confidences.json

### DIFF
--- a/src/alphafold3/model/confidence_types.py
+++ b/src/alphafold3/model/confidence_types.py
@@ -238,6 +238,9 @@ class StructureConfidenceSummary:
         # Cast to np.float64 before rounding, since casting to Python float will
         # cast to a 64 bit float, potentially undoing np.float32 rounding.
         rounded_data = np.round(data.astype(np.float64), decimals=2).tolist()
+      elif isinstance(data, str):
+        # String leaves (e.g. chain_ids entries) are passed through unchanged.
+        rounded_data = data
       else:
         rounded_data = np.round(data, decimals=2)
       return rounded_data

--- a/src/alphafold3/model/confidence_types.py
+++ b/src/alphafold3/model/confidence_types.py
@@ -196,6 +196,7 @@ class StructureConfidenceSummary:
    chain_pair_iptm: [num_chains, num_chains] Chain pair ipTM.
    chain_ptm: [num_chains] Chain pTM.
    chain_iptm: [num_chains] Mean cross chain ipTM for a chain.
+   chain_ids: [num_chains] Unique chain IDs in the same order as the chain-level arrays
   """
 
   ptm: float
@@ -207,12 +208,15 @@ class StructureConfidenceSummary:
   chain_pair_iptm: np.ndarray
   chain_ptm: np.ndarray
   chain_iptm: np.ndarray
+  chain_ids: list[str] = dataclasses.field(default_factory=list)
 
   @classmethod
   def from_inference_result(
       cls, inference_result: model.InferenceResult
   ) -> Self:
     """Returns a new instance based on a given inference result."""
+    token_chain_ids = inference_result.metadata['token_chain_ids']
+    chain_ids = list(dict.fromkeys(str(c) for c in token_chain_ids))
     return cls(
         ptm=float(inference_result.metadata['ptm']),
         iptm=float(inference_result.metadata['iptm']),
@@ -225,6 +229,7 @@ class StructureConfidenceSummary:
         chain_pair_iptm=inference_result.metadata['chain_pair_iptm'],
         chain_ptm=inference_result.metadata['iptm_ichain'],
         chain_iptm=inference_result.metadata['iptm_xchain'],
+        chain_ids=chain_ids,
     )
 
   @classmethod


### PR DESCRIPTION
chain_ptm, chain_iptm, chain_pair_iptm, and chain_pair_pae_min are currently positional arrays. To read them you must cross-reference token_chain_ids in the separate confidences.json file. This is error-prone, especially with multiple chains, where the mapping between index and chain is non-obvious.

This PR replaces the arrays with dicts keyed by chain ID, e.g.:
```
"chain_ptm": {"A": 0.73, "EA": 0.86, "LB": 0.04}
"chain_pair_iptm": {"A": {"A": 0.73, "EA": 0.37}, "EA": {"A": 0.37, "EA": 0.86}}
```

Each score is now self-describing. No new fields are added.

**AI usage disclosure**: AI tools were used to assist in generating parts of the code and PR description. The resulting changes were manually reviewed, edited, and tested by the author before submission.