### PR TITLE
Bugfix: Early validation of model seeds

### DIFF
--- a/src/alphafold3/common/folding_input.py
+++ b/src/alphafold3/common/folding_input.py
@@ -1013,16 +1013,17 @@ class Input:
   def ligands(self) -> Sequence[Ligand]:
     return [chain for chain in self.chains if isinstance(chain, Ligand)]
 
+  @staticmethod
+  def _validate_seed(seed: int) -> int:
+    if not (0 <= seed <= 2**32 - 1):
+        raise ValueError(f"Seed must be between 0 and 2**32 - 1. Got: {seed}")
+    return seed
+
   def sanitised_name(self) -> str:
     """Returns sanitised version of the name that can be used as a filename."""
     spaceless_name = self.name.replace(' ', '_')
     allowed_chars = set(string.ascii_letters + string.digits + '_-.')
     return ''.join(l for l in spaceless_name if l in allowed_chars)
-
-  def _validate_seed(seed: int) -> int:
-    if not (0 <= seed <= 2**32 - 1):
-        raise ValueError(f"Seed must be between 0 and 2**32 - 1. Got: {seed}")
-    return seed
 
   @classmethod
   def from_alphafoldserver_fold_job(cls, fold_job: Mapping[str, Any]) -> Self:
@@ -1107,7 +1108,7 @@ class Input:
         raise ValueError(f'Unknown sequence type: {sequence}')
 
     if 'modelSeeds' in fold_job and fold_job['modelSeeds']:
-      rng_seeds = [_validate_seed(int(seed)) for seed in fold_job['modelSeeds']]
+      rng_seeds = [cls._validate_seed(int(seed)) for seed in fold_job['modelSeeds']]
     else:
       rng_seeds = [_sample_rng_seed()]
 
@@ -1259,7 +1260,7 @@ class Input:
     return cls(
         name=raw_json['name'],
         chains=chains,
-        rng_seeds=[_validate_seed(int(seed)) for seed in raw_json['modelSeeds']],
+        rng_seeds=[cls._validate_seed(int(seed)) for seed in raw_json['modelSeeds']],
         bonded_atom_pairs=bonded_atom_pairs,
         user_ccd=user_ccd,
     )

--- a/src/alphafold3/common/folding_input.py
+++ b/src/alphafold3/common/folding_input.py
@@ -1019,6 +1019,11 @@ class Input:
     allowed_chars = set(string.ascii_letters + string.digits + '_-.')
     return ''.join(l for l in spaceless_name if l in allowed_chars)
 
+  def _validate_seed(seed: int) -> int:
+    if not (0 <= seed <= 2**32 - 1):
+        raise ValueError(f"Seed must be between 0 and 2**32 - 1. Got: {seed}")
+    return seed
+
   @classmethod
   def from_alphafoldserver_fold_job(cls, fold_job: Mapping[str, Any]) -> Self:
     """Constructs Input from an AlphaFoldServer fold job."""
@@ -1102,7 +1107,7 @@ class Input:
         raise ValueError(f'Unknown sequence type: {sequence}')
 
     if 'modelSeeds' in fold_job and fold_job['modelSeeds']:
-      rng_seeds = [int(seed) for seed in fold_job['modelSeeds']]
+      rng_seeds = [_validate_seed(int(seed)) for seed in fold_job['modelSeeds']]
     else:
       rng_seeds = [_sample_rng_seed()]
 
@@ -1254,7 +1259,7 @@ class Input:
     return cls(
         name=raw_json['name'],
         chains=chains,
-        rng_seeds=[int(seed) for seed in raw_json['modelSeeds']],
+        rng_seeds=[_validate_seed(int(seed)) for seed in raw_json['modelSeeds']],
         bonded_atom_pairs=bonded_atom_pairs,
         user_ccd=user_ccd,
     )


### PR DESCRIPTION
**The bug:** Invalid modelSeeds values were allowed to pass input parsing and only failed deep inside np.random.RandomState, causing late NumPy errors during featurization.

**The fix:** Early validate seed uint32 range required by np.random.RandomState, failing fast before featurization.

**AI usage disclosure:** AI tools were used to assist in generating parts of the code and PR description. The resulting changes were manually reviewed, edited, and tested by the author before submission.