### PR TITLE
Fix templateIndices serialization crash for empty query_to_template_map

### DIFF
--- a/src/alphafold3/common/folding_input.py
+++ b/src/alphafold3/common/folding_input.py
@@ -410,9 +410,7 @@ class ProteinChain:
           {
               'mmcif': template.mmcif,
               'queryIndices': list(template.query_to_template_map.keys()),
-              'templateIndices': (
-                  list(template.query_to_template_map.values()) or None
-              ),
+              'templateIndices': list(template.query_to_template_map.values()),
           }
           for template in self._templates
       ]


### PR DESCRIPTION
When a ProteinChain template has an empty query_to_template_map,
`list(values) or None` serializes templateIndices as null. On
deserialization, from_dict calls zip(queryIndices, None) which raises:

    TypeError: zip argument #2 must support iteration

Fix: remove `or None` so an empty map serializes as [], consistent with
how queryIndices is already written on the line above.

Files changed

- src/alphafold3/common/folding_input.py -- 1 line removed