### PR TITLE
Harden data-pipeline reliability and CLI failure modes

### DIFF
--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -255,7 +255,7 @@ _JACKHMMER_N_CPU = flags.DEFINE_integer(
     _num_cpus_for_msa_tools(),
     'Number of CPUs to use for Jackhmmer. Defaults to min(cpu_count, 8). Going'
     ' above 8 CPUs provides very little additional speedup.',
-    lower_bound=0,
+    lower_bound=1,
 )
 _JACKHMMER_MAX_PARALLEL_SHARDS = flags.DEFINE_integer(
     'jackhmmer_max_parallel_shards',
@@ -270,7 +270,7 @@ _NHMMER_N_CPU = flags.DEFINE_integer(
     _num_cpus_for_msa_tools(),
     'Number of CPUs to use for Nhmmer. Defaults to min(cpu_count, 8). Going'
     ' above 8 CPUs provides very little additional speedup.',
-    lower_bound=0,
+    lower_bound=1,
 )
 _NHMMER_MAX_PARALLEL_SHARDS = flags.DEFINE_integer(
     'nhmmer_max_parallel_shards',
@@ -278,6 +278,13 @@ _NHMMER_MAX_PARALLEL_SHARDS = flags.DEFINE_integer(
     'Maximum number of shards to search against in parallel. If unset, one'
     ' Nhmmer instance will be run per shard. Only applicable if the'
     ' database is sharded.',
+    lower_bound=1,
+)
+_HMMSEARCH_N_CPU = flags.DEFINE_integer(
+    'hmmsearch_n_cpu',
+    _num_cpus_for_msa_tools(),
+    'Number of CPUs to use for Hmmsearch during template search. Defaults to'
+    ' min(cpu_count, 8).',
     lower_bound=1,
 )
 
@@ -914,9 +921,18 @@ def main(_):
     )
 
   if _INPUT_DIR.value is not None:
-    fold_inputs = folding_input.load_fold_inputs_from_dir(_INPUT_DIR.value)
+    fold_inputs = list(
+        folding_input.load_fold_inputs_from_dir(_INPUT_DIR.value)
+    )
+    if not fold_inputs:
+      raise ValueError(
+          f'No fold inputs found in --input_dir={_INPUT_DIR.value}. Provide at'
+          ' least one *.json file, or use --json_path for a single input.'
+      )
   elif _JSON_PATH.value is not None:
-    fold_inputs = folding_input.load_fold_inputs_from_path(_JSON_PATH.value)
+    fold_inputs = list(
+        folding_input.load_fold_inputs_from_path(_JSON_PATH.value)
+    )
   else:
     raise AssertionError(
         'Exactly one of --json_path or --input_dir must be specified.'
@@ -942,32 +958,43 @@ def main(_):
         )
     elif _JAX_BACKEND.value == JaxBackend.GPU:
       gpu_devices = jax.local_devices(backend='gpu')
-      if gpu_devices:
-        compute_capability = float(
-            gpu_devices[_GPU_DEVICE.value].compute_capability
+      if not gpu_devices:
+        raise ValueError(
+            'No GPU devices found for --jax_backend=gpu. Use --jax_backend=cpu'
+            ' for CPU inference, or ensure a CUDA GPU is visible to the'
+            ' process.'
         )
-        if compute_capability < 6.0:
+      if not 0 <= _GPU_DEVICE.value < len(gpu_devices):
+        raise ValueError(
+            f'--gpu_device={_GPU_DEVICE.value} is out of range; found'
+            f' {len(gpu_devices)} GPU device(s) with indices'
+            f' 0..{len(gpu_devices) - 1}.'
+        )
+      compute_capability = float(
+          gpu_devices[_GPU_DEVICE.value].compute_capability
+      )
+      if compute_capability < 6.0:
+        raise ValueError(
+            'AlphaFold 3 requires at least GPU compute capability 6.0 (see'
+            ' https://developer.nvidia.com/cuda-gpus).'
+        )
+      elif 7.0 <= compute_capability < 8.0:
+        xla_flags = os.environ.get('XLA_FLAGS')
+        required_flag = (
+            '--xla_disable_hlo_passes=custom-kernel-fusion-rewriter'
+        )
+        if not xla_flags or required_flag not in xla_flags:
           raise ValueError(
-              'AlphaFold 3 requires at least GPU compute capability 6.0 (see'
-              ' https://developer.nvidia.com/cuda-gpus).'
+              'For devices with GPU compute capability 7.x (see'
+              ' https://developer.nvidia.com/cuda-gpus) the ENV XLA_FLAGS'
+              f' must include "{required_flag}".'
           )
-        elif 7.0 <= compute_capability < 8.0:
-          xla_flags = os.environ.get('XLA_FLAGS')
-          required_flag = (
-              '--xla_disable_hlo_passes=custom-kernel-fusion-rewriter'
+        if _FLASH_ATTENTION_IMPLEMENTATION.value != 'xla':
+          raise ValueError(
+              'For devices with GPU compute capability 7.x (see'
+              ' https://developer.nvidia.com/cuda-gpus) the'
+              ' --flash_attention_implementation must be set to "xla".'
           )
-          if not xla_flags or required_flag not in xla_flags:
-            raise ValueError(
-                'For devices with GPU compute capability 7.x (see'
-                ' https://developer.nvidia.com/cuda-gpus) the ENV XLA_FLAGS'
-                f' must include "{required_flag}".'
-            )
-          if _FLASH_ATTENTION_IMPLEMENTATION.value != 'xla':
-            raise ValueError(
-                'For devices with GPU compute capability 7.x (see'
-                ' https://developer.nvidia.com/cuda-gpus) the'
-                ' --flash_attention_implementation must be set to "xla".'
-            )
     else:
       raise ValueError(f'Unsupported JAX backend: {_JAX_BACKEND.value}')
 
@@ -986,6 +1013,19 @@ def main(_):
 
   max_template_date = datetime.date.fromisoformat(_MAX_TEMPLATE_DATE.value)
   if _RUN_DATA_PIPELINE.value:
+    binary_flags = (
+        ('Jackhmmer', _JACKHMMER_BINARY_PATH.value, 'jackhmmer_binary_path'),
+        ('Nhmmer', _NHMMER_BINARY_PATH.value, 'nhmmer_binary_path'),
+        ('Hmmalign', _HMMALIGN_BINARY_PATH.value, 'hmmalign_binary_path'),
+        ('Hmmsearch', _HMMSEARCH_BINARY_PATH.value, 'hmmsearch_binary_path'),
+        ('Hmmbuild', _HMMBUILD_BINARY_PATH.value, 'hmmbuild_binary_path'),
+    )
+    for binary_name, binary_path, flag_name in binary_flags:
+      if not binary_path:
+        raise ValueError(
+            f'{binary_name} binary not found on PATH. Install HMMER tools or'
+            f' set --{flag_name} to an absolute path.'
+        )
     expand_path = lambda x: replace_db_dir(x, DB_DIR.value)
     data_pipeline_config = pipeline.DataPipelineConfig(
         jackhmmer_binary_path=_JACKHMMER_BINARY_PATH.value,  # pyrefly: ignore[bad-argument-type]
@@ -1015,6 +1055,7 @@ def main(_):
         jackhmmer_max_parallel_shards=_JACKHMMER_MAX_PARALLEL_SHARDS.value,
         nhmmer_n_cpu=_NHMMER_N_CPU.value,
         nhmmer_max_parallel_shards=_NHMMER_MAX_PARALLEL_SHARDS.value,
+        hmmsearch_n_cpu=_HMMSEARCH_N_CPU.value,
         max_template_date=max_template_date,
     )
   else:

--- a/src/alphafold3/data/msa_config.py
+++ b/src/alphafold3/data/msa_config.py
@@ -146,6 +146,7 @@ class HmmsearchConfig:
   filter_f2: float | None = None
   filter_f3: float | None = None
   filter_max: bool = False
+  n_cpu: int = 8
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True, slots=True)

--- a/src/alphafold3/data/pipeline.py
+++ b/src/alphafold3/data/pipeline.py
@@ -35,6 +35,14 @@ from alphafold3.data import templates as templates_lib
 from etils import epath
 
 
+# Cache to avoid re-opening the same PDB structure store for every sequence.
+@functools.cache
+def _get_structure_store(
+    pdb_database_path: epath.PathLike,
+) -> structure_stores.StructureStore:
+  return structure_stores.StructureStore(pdb_database_path)
+
+
 # Cache to avoid re-running template search for the same sequence in homomers.
 @functools.cache
 def _get_protein_templates(
@@ -45,6 +53,7 @@ def _get_protein_templates(
     pdb_database_path: epath.PathLike,
 ) -> templates_lib.Templates:
   """Searches for templates for a single protein chain."""
+  structure_store = _get_structure_store(pdb_database_path)
   if run_template_search:
     templates_start_time = time.time()
     logging.info('Getting protein templates for sequence %s', sequence)
@@ -56,7 +65,7 @@ def _get_protein_templates(
         hmmsearch_config=templates_config.template_tool_config.hmmsearch_config,
         max_a3m_query_sequences=None,
         chain_poly_type=mmcif_names.PROTEIN_CHAIN,
-        structure_store=structure_stores.StructureStore(pdb_database_path),
+        structure_store=structure_store,
         filter_config=templates_config.filter_config,
     )
     logging.info(
@@ -71,7 +80,7 @@ def _get_protein_templates(
         query_sequence=sequence,
         hits=[],
         max_template_date=templates_config.filter_config.max_template_date,
-        structure_store=structure_stores.StructureStore(pdb_database_path),
+        structure_store=structure_store,
     )
   return protein_templates
 
@@ -260,6 +269,7 @@ class DataPipelineConfig:
     nhmmer_max_parallel_shards: Maximum number of shards to search against in
       parallel. If None, one Nhmmer instance will be run per shard. Only
       applicable if the database is sharded.
+    hmmsearch_n_cpu: Number of CPUs to use for Hmmsearch during template search.
     max_template_date: The latest date of templates to use.
   """
 
@@ -295,6 +305,7 @@ class DataPipelineConfig:
   jackhmmer_max_parallel_shards: int | None = None
   nhmmer_n_cpu: int = 8
   nhmmer_max_parallel_shards: int | None = None
+  hmmsearch_n_cpu: int = 8
 
   max_template_date: datetime.date
 
@@ -451,6 +462,7 @@ class DataPipeline:
                 dom_e=100,
                 incdom_e=100,
                 alphabet='amino',
+                n_cpu=data_pipeline_config.hmmsearch_n_cpu,
             ),
         ),
         filter_config=msa_config.TemplateFilterConfig(

--- a/src/alphafold3/data/pipeline_reliability_test.py
+++ b/src/alphafold3/data/pipeline_reliability_test.py
@@ -1,0 +1,130 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for data-pipeline reliability fixes."""
+
+import io
+import os
+import pathlib
+import tarfile
+import tempfile
+from unittest import mock
+
+from absl.testing import absltest
+
+from alphafold3.data import structure_stores
+from alphafold3.data.tools import hmmsearch
+from alphafold3.data.tools import subprocess_utils
+
+
+class CheckBinaryExistsTest(absltest.TestCase):
+
+  def test_rejects_none_path(self):
+    with self.assertRaisesRegex(RuntimeError, 'not set'):
+      subprocess_utils.check_binary_exists(None, 'Jackhmmer')
+
+  def test_rejects_empty_path(self):
+    with self.assertRaisesRegex(RuntimeError, 'not set'):
+      subprocess_utils.check_binary_exists('', 'Jackhmmer')
+
+  def test_rejects_missing_path(self):
+    with self.assertRaisesRegex(RuntimeError, 'not found'):
+      subprocess_utils.check_binary_exists(
+          '/path/does/not/exist/jackhmmer', 'Jackhmmer'
+      )
+
+  def test_accepts_existing_path(self):
+    with tempfile.NamedTemporaryFile() as tmp:
+      subprocess_utils.check_binary_exists(tmp.name, 'FakeBinary')
+
+
+class StructureStoreLifecycleTest(absltest.TestCase):
+
+  def _make_cif_tar(self, tar_path: pathlib.Path) -> None:
+    cif_bytes = b'data_test\n_entry.id test\n'
+    with tarfile.open(tar_path, 'w') as tar:
+      info = tarfile.TarInfo(name='abcd.cif')
+      info.size = len(cif_bytes)
+      tar.addfile(info, io.BytesIO(cif_bytes))
+
+  def test_context_manager_closes_tar(self):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      tar_path = pathlib.Path(tmp_dir) / 'pdb.tar'
+      self._make_cif_tar(tar_path)
+      with structure_stores.StructureStore(tar_path) as store:
+        self.assertEqual(store.get_mmcif_str('abcd'), 'data_test\n_entry.id test\n')
+      with self.assertRaisesRegex(IOError, 'closed'):
+        store.get_mmcif_str('abcd')
+
+  def test_mapping_store_roundtrip(self):
+    store = structure_stores.StructureStore({'abcd': 'mmcif-data'})
+    self.assertEqual(store.get_mmcif_str('abcd'), 'mmcif-data')
+    store.close()
+
+
+class HmmsearchCpuFlagTest(absltest.TestCase):
+
+  def test_uses_configured_n_cpu(self):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      db_path = os.path.join(tmp_dir, 'db.fasta')
+      pathlib.Path(db_path).write_text('>db\nAAAA\n')
+      binary_path = os.path.join(tmp_dir, 'hmmsearch')
+      hmmbuild_path = os.path.join(tmp_dir, 'hmmbuild')
+      pathlib.Path(binary_path).write_text('#!/bin/sh\n')
+      pathlib.Path(hmmbuild_path).write_text('#!/bin/sh\n')
+      os.chmod(binary_path, 0o755)
+      os.chmod(hmmbuild_path, 0o755)
+
+      runner = hmmsearch.Hmmsearch(
+          binary_path=binary_path,
+          hmmbuild_binary_path=hmmbuild_path,
+          database_path=db_path,
+          n_cpu=3,
+      )
+
+      def _fake_run(*, cmd, **kwargs):
+        del kwargs
+        # Create the Stockholm output path passed via -A.
+        a_idx = cmd.index('-A')
+        pathlib.Path(cmd[a_idx + 1]).write_text('# STOCKHOLM 1.0\n//\n')
+        return mock.Mock()
+
+      with mock.patch.object(
+          hmmsearch.subprocess_utils, 'run', side_effect=_fake_run
+      ) as mock_run:
+        runner.query_with_hmm('HMM')
+
+      cmd = mock_run.call_args.kwargs['cmd']
+      cpu_idx = cmd.index('--cpu')
+      self.assertEqual(cmd[cpu_idx + 1], '3')
+
+  def test_rejects_invalid_n_cpu(self):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      db_path = os.path.join(tmp_dir, 'db.fasta')
+      pathlib.Path(db_path).write_text('>db\nAAAA\n')
+      binary_path = os.path.join(tmp_dir, 'hmmsearch')
+      hmmbuild_path = os.path.join(tmp_dir, 'hmmbuild')
+      pathlib.Path(binary_path).write_text('#!/bin/sh\n')
+      pathlib.Path(hmmbuild_path).write_text('#!/bin/sh\n')
+      with self.assertRaisesRegex(ValueError, 'n_cpu'):
+        hmmsearch.Hmmsearch(
+            binary_path=binary_path,
+            hmmbuild_binary_path=hmmbuild_path,
+            database_path=db_path,
+            n_cpu=0,
+        )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/src/alphafold3/data/structure_stores.py
+++ b/src/alphafold3/data/structure_stores.py
@@ -42,6 +42,8 @@ class StructureStore:
       structures: Path of the directory where the mmCIF files are or a Mapping
         from target name to mmCIF string.
     """
+    self._closed = False
+    self._structure_tar_fileobj = None
     if isinstance(structures, Mapping):
       self._structure_mapping = structures
       self._structure_path = None
@@ -51,8 +53,9 @@ class StructureStore:
       self._structure_mapping = None
       structures = epath.Path(structures)
       if structures.suffix == '.tar':
+        self._structure_tar_fileobj = structures.open('rb')
         self._structure_tar = tarfile.open(
-            fileobj=structures.open('rb'),
+            fileobj=self._structure_tar_fileobj,
             mode='r',
         )
         self._structure_path = None
@@ -60,6 +63,32 @@ class StructureStore:
       else:
         self._structure_path = structures
         self._structure_tar = None
+
+  def close(self) -> None:
+    """Closes any open archive handles held by the store."""
+    if self._closed:
+      return
+    if self._structure_tar is not None:
+      self._structure_tar.close()
+      self._structure_tar = None
+    if self._structure_tar_fileobj is not None:
+      self._structure_tar_fileobj.close()
+      self._structure_tar_fileobj = None
+    self._closed = True
+
+  def __enter__(self) -> 'StructureStore':
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback) -> None:
+    del exc_type, exc_value, traceback
+    self.close()
+
+  def __del__(self) -> None:
+    try:
+      self.close()
+    except Exception:  # pylint: disable=broad-exception-caught
+      # Destructors must not raise.
+      pass
 
   @functools.cached_property
   def _tar_members(self) -> Mapping[str, tarfile.TarInfo]:
@@ -80,6 +109,9 @@ class StructureStore:
     Raises:
       NotFoundError: If the target is not found.
     """
+    if self._closed:
+      raise IOError('StructureStore has been closed.')
+
     if self._structure_mapping is not None:
       try:
         return self._structure_mapping[target_name]

--- a/src/alphafold3/data/templates.py
+++ b/src/alphafold3/data/templates.py
@@ -986,6 +986,7 @@ def run_hmmsearch_with_a3m(
       filter_f2=hmmsearch_config.filter_f2,
       filter_f3=hmmsearch_config.filter_f3,
       filter_max=hmmsearch_config.filter_max,
+      n_cpu=hmmsearch_config.n_cpu,
   )
   # STO enables us to annotate query non-gap columns as reference columns.
   sto = parsers.convert_a3m_to_stockholm(a3m, max_a3m_query_sequences)  # pyrefly: ignore[bad-argument-type]

--- a/src/alphafold3/data/tools/hmmsearch.py
+++ b/src/alphafold3/data/tools/hmmsearch.py
@@ -46,6 +46,7 @@ class Hmmsearch(object):
       dom_e: float | None = None,
       incdom_e: float | None = None,
       filter_max: bool = False,
+      n_cpu: int = 8,
   ):
     """Initializes the Python hmmsearch wrapper.
 
@@ -64,11 +65,15 @@ class Hmmsearch(object):
       incdom_e: Domain e-value criteria for inclusion of domains in MSA/next
         round.
       filter_max: Remove all filters, will ignore all filter_f* settings.
+      n_cpu: Number of CPUs to give hmmsearch.
 
     Raises:
       RuntimeError: If hmmsearch binary not found within the path.
     """
+    if n_cpu < 1:
+      raise ValueError(f'n_cpu must be >= 1, got {n_cpu}.')
     self._binary_path = binary_path
+    self._n_cpu = n_cpu
     self._hmmbuild_runner = hmmbuild.Hmmbuild(
         alphabet=alphabet, binary_path=hmmbuild_binary_path
     )
@@ -114,7 +119,7 @@ class Hmmsearch(object):
       cmd = [
           self._binary_path,
           '--noali',  # Don't include the alignment in stdout.
-          *('--cpu', '8'),
+          *('--cpu', str(self._n_cpu)),
       ]
       # If adding flags, we have to do so before the output and input:
       if self._flags:

--- a/src/alphafold3/data/tools/jackhmmer.py
+++ b/src/alphafold3/data/tools/jackhmmer.py
@@ -156,30 +156,34 @@ class Jackhmmer(msa_tool.MsaTool):
       )
 
       global_temp_dir = tempfile.mkdtemp()
+      try:
 
-      def _query_shard_fn(
-          shard_path: str,
-      ) -> tuple[msa_tool.MsaToolResult, float]:
-        t_start = time.time()
-        result = self._query_db_shard(
-            target_sequence=target_sequence,
-            db_shard_path=shard_path,
-            get_tblout=True,  # Tblout contains e-values needed for merging.
-            global_temp_dir=global_temp_dir,
+        def _query_shard_fn(
+            shard_path: str,
+        ) -> tuple[msa_tool.MsaToolResult, float]:
+          t_start = time.time()
+          result = self._query_db_shard(
+              target_sequence=target_sequence,
+              db_shard_path=shard_path,
+              get_tblout=True,  # Tblout contains e-values needed for merging.
+              global_temp_dir=global_temp_dir,
+          )
+          return result, time.time() - t_start
+
+        with futures.ThreadPoolExecutor(max_workers=self._max_threads) as ex:
+          tool_outputs, timings = zip(
+              *ex.map(_query_shard_fn, self._shard_paths)
+          )
+
+        logging.info(
+            'Finished query for %d shards, shard timings (seconds): %s',
+            len(tool_outputs),
+            ', '.join(f'{t:.1f}' for t in timings),
         )
-        return result, time.time() - t_start
 
-      with futures.ThreadPoolExecutor(max_workers=self._max_threads) as ex:
-        tool_outputs, timings = zip(*ex.map(_query_shard_fn, self._shard_paths))
-
-      logging.info(
-          'Finished query for %d shards, shard timings (seconds): %s',
-          len(tool_outputs),
-          ', '.join(f'{t:.1f}' for t in timings),
-      )
-
-      shutil.rmtree(global_temp_dir, ignore_errors=True)
-      return _merge_jackhmmer_results(tool_outputs, self._max_sequences)
+        return _merge_jackhmmer_results(tool_outputs, self._max_sequences)
+      finally:
+        shutil.rmtree(global_temp_dir, ignore_errors=True)
 
     else:
       # Non-sharded case, run the query against the whole database.

--- a/src/alphafold3/data/tools/nhmmer.py
+++ b/src/alphafold3/data/tools/nhmmer.py
@@ -157,31 +157,35 @@ class Nhmmer(msa_tool.MsaTool):
       )
 
       global_temp_dir = tempfile.mkdtemp()
+      try:
 
-      def _query_shard_fn(
-          shard_path: str,
-      ) -> tuple[msa_tool.MsaToolResult, float]:
-        t_start = time.time()
-        # Get tblout as it contains e-values we need for merging sequences.
-        result = self._query_db_shard(
-            target_sequence=target_sequence,
-            db_shard_path=shard_path,
-            get_tblout=True,  # Tblout contains e-values needed for merging.
-            global_temp_dir=global_temp_dir,
+        def _query_shard_fn(
+            shard_path: str,
+        ) -> tuple[msa_tool.MsaToolResult, float]:
+          t_start = time.time()
+          # Get tblout as it contains e-values we need for merging sequences.
+          result = self._query_db_shard(
+              target_sequence=target_sequence,
+              db_shard_path=shard_path,
+              get_tblout=True,  # Tblout contains e-values needed for merging.
+              global_temp_dir=global_temp_dir,
+          )
+          return result, time.time() - t_start
+
+        with futures.ThreadPoolExecutor(max_workers=self._max_threads) as ex:
+          tool_outputs, timings = zip(
+              *ex.map(_query_shard_fn, self._shard_paths)
+          )
+
+        logging.info(
+            'Finished query for %d shards, shard timings (seconds): %s',
+            len(tool_outputs),
+            ', '.join(f'{t:.1f}' for t in timings),
         )
-        return result, time.time() - t_start
 
-      with futures.ThreadPoolExecutor(max_workers=self._max_threads) as ex:
-        tool_outputs, timings = zip(*ex.map(_query_shard_fn, self._shard_paths))
-
-      logging.info(
-          'Finished query for %d shards, shard timings (seconds): %s',
-          len(tool_outputs),
-          ', '.join(f'{t:.1f}' for t in timings),
-      )
-
-      shutil.rmtree(global_temp_dir, ignore_errors=True)
-      return _merge_nhmmer_results(tool_outputs, self._max_sequences)
+        return _merge_nhmmer_results(tool_outputs, self._max_sequences)
+      finally:
+        shutil.rmtree(global_temp_dir, ignore_errors=True)
 
     else:
       # Non-sharded case, run the query against the whole database.

--- a/src/alphafold3/data/tools/subprocess_utils.py
+++ b/src/alphafold3/data/tools/subprocess_utils.py
@@ -39,8 +39,13 @@ def create_query_fasta_file(sequence: str, path: str, linewidth: int = 80):
       i += linewidth
 
 
-def check_binary_exists(path: str, name: str) -> None:
+def check_binary_exists(path: str | None, name: str) -> None:
   """Checks if a binary exists on the given path and raises otherwise."""
+  if not path:
+    raise RuntimeError(
+        f'{name} binary path is not set. Install the tool and ensure it is on'
+        f' PATH, or pass an explicit binary path.'
+    )
   if not os.path.exists(path):
     raise RuntimeError(f'{name} binary not found at {path}')
 


### PR DESCRIPTION
## Summary
- Fail early with clear errors when HMMER binaries are missing from PATH (`None` previously caused a cryptic `TypeError` in `os.path.exists`), when `--jax_backend=gpu` finds no GPUs / an out-of-range `--gpu_device`, and when `--input_dir` contains no JSON inputs.
- Always clean up sharded Jackhmmer/Nhmmer temp directories on failure (`try`/`finally`), instead of leaking large temp trees after shard errors.
- Share a single cached `StructureStore` per PDB path and add `close()` / context-manager support so tar-backed stores do not accumulate open file handles across sequences.
- Make Hmmsearch CPU count configurable (`--hmmsearch_n_cpu`, default `min(cpu_count, 8)`) instead of hardcoding `--cpu 8`; raise Jackhmmer/Nhmmer CPU lower bounds from 0 to 1.
- Add unit tests for binary-path checks, StructureStore lifecycle, and Hmmsearch CPU flag wiring (`pipeline_reliability_test.py`, 8 tests, all passing).

## Why
These are independent reliability gaps that hurt local installs and batch/sharded runs. None of them are covered by existing open/closed issues; they improve real failure modes and resource hygiene without changing model behavior.

## Test plan
- [x] `python src/alphafold3/data/pipeline_reliability_test.py` — 8/8 passed
- [x] Run with HMMER unset on PATH and `--run_data_pipeline=true` — expect clear binary-missing error
- [x] Run `--jax_backend=gpu` with no GPU — expect clear no-device error
- [x] Interrupt/fail a sharded Jackhmmer query — confirm temp dir is removed
- [x] Confirm `--hmmsearch_n_cpu=N` is forwarded to the hmmsearch command line