### PR TITLE
Fix loading input JSON written by AlphaFold 3 <= 3.0.3

### DIFF
--- a/src/alphafold3/common/folding_input.py
+++ b/src/alphafold3/common/folding_input.py
@@ -386,7 +386,12 @@ class ProteinChain:
         if mmcif_path:
           mmcif = _read_file(path=mmcif_path, json_path=json_path)
         query_to_template_map = dict(
-            zip(raw_template['queryIndices'], raw_template['templateIndices'])
+            zip(
+                raw_template['queryIndices'],
+                # AlphaFold 3 <= 3.0.3 wrote null here for an empty map.
+                raw_template['templateIndices'] or [],
+                strict=True,
+            )
         )
         templates.append(
             Template(mmcif=mmcif, query_to_template_map=query_to_template_map)


### PR DESCRIPTION
A user has an input JSON saved by an earlier version of AlphaFold 3. They upgrade to 3.0.4, re-run the same file, and it crashes with:

    TypeError: 'NoneType' object is not iterable

Nothing in the error points at the input file or at the version change, so there is no obvious way to work out what went wrong.

Cause:

Templates written by AlphaFold 3 3.0.0 through 3.0.3 serialize an empty query_to_template_map as "templateIndices": null. The write side was fixed in 62136ec, but the read side still passes that null straight into zip():

    query_to_template_map = dict(
        zip(raw_template['queryIndices'], raw_template['templateIndices'])
    )

JSON_VERSIONS is (1, 2, 3, 4), so reading input JSON produced by earlier versions is supported, and every release before 3.0.4 wrote null.

Also in this change:

Adding strict=True. Without it, queryIndices and templateIndices of different lengths are silently truncated rather than rejected, so a malformed input folds against a wrong template alignment and returns a structure with no error raised. The same file already uses strict=True on lines 1194 and 1352.

The two changes are safe together: the old code serialized keys() and values() of the same dict, so null could only ever occur alongside an empty queryIndices, meaning the lengths always match for legacy files.

Verified:

- Legacy file ("templateIndices": null) loads to an empty map instead of
  raising TypeError.
- Mismatched lengths raise ValueError instead of silently dropping query
  residues.
- Files written by 3.0.4 are unaffected.

Happy to drop the strict=True half if you would rather keep this purely to the backwards compatibility fix.