### PR TITLE
Avoid float32 overflow when ranking paired MSA rows.

### DIFF
--- a/src/alphafold3/model/msa_pairing.py
+++ b/src/alphafold3/model/msa_pairing.py
@@ -177,7 +177,10 @@ def create_paired_features(
     )
     # Sort rows by the product of the original indices in the respective chain
     # MSAS, so as to rank hits that appear higher in the original MSAs higher.
-    rank_metric = np.abs(np.prod(rows.astype(np.float32), axis=1))
+    # Sum the logs instead of multiplying: with enough chains the product
+    # overflows float32, every row becomes inf and the ordering is lost.
+    with np.errstate(divide='ignore'):  # log(0) is -inf, which sorts first.
+      rank_metric = np.sum(np.log(np.abs(rows).astype(np.float64)), axis=1)
     sorted_rows = rows[np.argsort(rank_metric), :]
     all_rows.append(sorted_rows)
     num_rows_seen += rows.shape[0]


### PR DESCRIPTION
The rank metric multiplies one MSA row index per chain in float32. With a dozen chains and deep MSAs that product is well past 3.4e38, so every row comes out as inf and argsort no longer orders anything - the pairing keeps an arbitrary 8192 rows instead of the ones highest up the input MSAs. It also produces the "overflow encountered in reduce" warning in issue 236.

Sum the logs instead, which gives the same order without the overflow.