### PR TITLE
Fix float32 overflow when ranking paired MSA rows

### DIFF
--- a/src/alphafold3/model/msa_pairing.py
+++ b/src/alphafold3/model/msa_pairing.py
@@ -177,7 +177,16 @@ def create_paired_features(
     )
     # Sort rows by the product of the original indices in the respective chain
     # MSAS, so as to rank hits that appear higher in the original MSAs higher.
-    rank_metric = np.abs(np.prod(rows.astype(np.float32), axis=1))
+    # The product is computed in the log domain to avoid float32 overflow:
+    # with deep MSAs and many chains the raw product of row indices easily
+    # exceeds the float32 range (~3.4e38), which silently corrupts the
+    # ordering (see https://github.com/google-deepmind/alphafold3/issues/236).
+    # As log is monotonic, summing the logs yields the same ordering as the
+    # product. Padding rows (index -1) contribute log(abs(-1)) = 0, and rows
+    # containing the query (index 0) contribute -inf, so they sort first, both
+    # matching the original product semantics.
+    with np.errstate(divide='ignore'):
+      rank_metric = np.sum(np.log(np.abs(rows).astype(np.float64)), axis=1)
     sorted_rows = rows[np.argsort(rank_metric), :]
     all_rows.append(sorted_rows)
     num_rows_seen += rows.shape[0]
@@ -210,7 +219,7 @@ def create_paired_features(
       feat_value = feat_value[selected_row_indices, :]
       out_chain[all_seq_name] = feat_value
     out_chain['num_alignments_all_seq'] = np.array(
-        out_chain['msa_all_seq'].shape[0]
+        out_chain['msa_all_seq'].shape[0], dtype=np.int32
     )
     paired_chains.append(out_chain)
   return paired_chains
@@ -228,14 +237,14 @@ def deduplicate_unpaired_sequences(
   )
 
   for chain in np_chains:
-    sequence_set = set(
-        hash(s.data.tobytes()) for s in chain['msa_all_seq'].astype(np.int8)
-    )
+    sequence_set = {
+        s.tobytes() for s in chain['msa_all_seq'].astype(np.int8)
+    }
     keep_rows = []
     # Go through unpaired MSA seqs and remove any rows that correspond to the
     # sequences that are already present in the paired MSA.
     for row_num, seq in enumerate(chain['msa'].astype(np.int8)):
-      if hash(seq.data.tobytes()) not in sequence_set:
+      if seq.tobytes() not in sequence_set:
         keep_rows.append(row_num)
     for feature_name in feature_names:
       if feature_name in msa_features:

--- a/src/alphafold3/model/msa_pairing_test.py
+++ b/src/alphafold3/model/msa_pairing_test.py
@@ -1,0 +1,124 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these
+# if received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
+
+"""Tests for MSA pairing (see issue #236 for the float32 overflow)."""
+
+from absl.testing import absltest
+from alphafold3.model import msa_pairing
+import numpy as np
+
+
+def _rank_metric_log(rows: np.ndarray) -> np.ndarray:
+  """Reference log-domain ranking matching the production fix."""
+  with np.errstate(divide='ignore'):
+    return np.sum(np.log(np.abs(rows).astype(np.float64)), axis=1)
+
+
+def _rank_metric_int64(rows: np.ndarray) -> np.ndarray:
+  """Exact integer ranking, only safe for small values."""
+  return np.abs(np.prod(rows.astype(np.int64), axis=1))
+
+
+class MsaPairingTest(absltest.TestCase):
+
+  def test_rank_metric_does_not_overflow_float32(self):
+    # Regression test for issue #236: with deep MSAs and many chains the raw
+    # float32 product of row indices overflows to inf, silently corrupting the
+    # pairing order.
+    rng = np.random.RandomState(0)
+    rows = rng.randint(1, 8000, size=(100, 12)).astype(np.int32)
+    old_metric = np.abs(np.prod(rows.astype(np.float32), axis=1))
+    self.assertTrue(np.isinf(old_metric).any())
+    new_metric = _rank_metric_log(rows)
+    self.assertTrue(np.isfinite(new_metric).all())
+
+  def test_log_rank_matches_int64_rank_for_small_values(self):
+    rows = np.array(
+        [[3, 2], [1, 5], [2, 2], [5, 1], [1, 1], [0, 5], [1, -1]],
+        dtype=np.int32,
+    )
+    self.assertSequenceEqual(
+        np.argsort(_rank_metric_log(rows)).tolist(),
+        np.argsort(_rank_metric_int64(rows)).tolist(),
+    )
+
+  def test_query_and_padding_rows_rank_first(self):
+    # Query rows (index 0) and fully-padded rows (product 1) must sort before
+    # any real hit, matching the original product semantics.
+    rows = np.array(
+        [[0, 0], [1, -1], [2, 3], [4, 5]],
+        dtype=np.int32,
+    )
+    order = np.argsort(_rank_metric_log(rows))
+    self.assertEqual(order[0], 0)
+    self.assertEqual(order[1], 1)
+
+  def test_create_paired_features_with_deep_msa(self):
+    # End-to-end check that create_paired_features survives deep MSAs over many
+    # chains without the float32 overflow.
+    rng = np.random.RandomState(42)
+    num_chains = 8
+    num_rows = 6000
+    chains = []
+    for c in range(num_chains):
+      species = np.array(
+          [b'sp%02d' % rng.randint(0, 5) for _ in range(num_rows)], dtype=object
+      )
+      species[0] = b''
+      msa = np.zeros((num_rows, 16), dtype=np.int32)
+      chains.append({
+          'chain_id': str(c),
+          'msa_species_identifiers_all_seq': species,
+          'msa_all_seq': msa,
+          'deletion_matrix_all_seq': np.zeros_like(msa),
+          'msa': np.zeros((num_rows, 16), dtype=np.int32),
+          'deletion_matrix': np.zeros_like(msa),
+      })
+    out = msa_pairing.create_paired_features(
+        chains,
+        max_paired_sequences=1024,
+        nonempty_chain_ids={str(c) for c in range(num_chains)},
+        max_hits_per_species=600,
+    )
+    for chain in out:
+      self.assertEqual(chain['msa_all_seq'].shape[0], 1024)
+      self.assertEqual(int(chain['num_alignments_all_seq']), 1024)
+      self.assertEqual(chain['num_alignments_all_seq'].dtype, np.int32)
+
+  def test_deduplicate_unpaired_sequences_uses_bytes_not_hash(self):
+    paired = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+    unpaired = np.array(
+        [[4, 5, 6], [7, 8, 9], [1, 2, 3], [10, 11, 12]], dtype=np.int32
+    )
+    chain = {
+        'msa_all_seq': paired,
+        'msa': unpaired,
+        'deletion_matrix_all_seq': np.zeros_like(paired),
+        'deletion_matrix': np.zeros_like(unpaired),
+        'num_alignments': np.array(4, dtype=np.int32),
+    }
+    # Rows present in the paired MSA must be removed from the unpaired MSA,
+    # leaving only the two unique rows.
+    out = msa_pairing.deduplicate_unpaired_sequences([chain])[0]
+    self.assertEqual(out['msa'].shape[0], 2)
+    self.assertEqual(int(out['num_alignments']), 2)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

The pairing rank metric in `msa_pairing.create_paired_features` was computed as a float32 product of one MSA row index per chain:

```python
rank_metric = np.abs(np.prod(rows.astype(np.float32), axis=1))
```

With deep MSAs and many chains, that product exceeds the float32 range (~3.4e38), so every row ranks as `inf` and `np.argsort` no longer orders anything â€” the pairing keeps arbitrary rows instead of the ones highest up the input MSAs. It also produces the `RuntimeWarning: overflow encountered in reduce` reported in #236.

## Fix

Compute the rank in the log domain. Because `log` is monotonic, summing the logs of the absolute row indices yields the same ordering as the product, without overflowing. Padding rows (index `-1`) contribute `log(abs(-1)) = 0` and query rows (index `0`) contribute `-inf`, so they sort first, both matching the original product semantics.

```python
with np.errstate(divide='ignore'):
  rank_metric = np.sum(np.log(np.abs(rows).astype(np.float64)), axis=1)
```

Also:

- `deduplicate_unpaired_sequences`: compare sequences by raw bytes instead of `hash()`, avoiding salted-hash collisions (Python's string/bytes hash is randomized per-process) that could wrongly drop kept rows or fail to drop duplicates.
- `deduplicate_unpaired_sequences`: emit `num_alignments_all_seq` as `int32`, matching `create_paired_features`, instead of `int64`.

## Tests

Added `msa_pairing_test.py` with regression coverage:

- Float32 overflow reproduces with 12 chains Ã— deep MSAs and the log-domain metric stays finite.
- Log-domain ordering matches the exact int64 product ordering for small values.
- Query and padding rows rank first.
- End-to-end `create_paired_features` survives deep MSAs over 8 chains.
- Dedup uses bytes, not hashes.

All pass:

```
5 passed in 0.71s
```

## AI disclosure

Code and tests generated with AI assistance and manually reviewed.