### PR TITLE
Make template hit parsing resilient to corrupt hits

### DIFF
--- a/src/alphafold3/data/structure_stores.py
+++ b/src/alphafold3/data/structure_stores.py
@@ -21,12 +21,21 @@
 
 from collections.abc import Mapping, Sequence
 import functools
+import gzip
+import io
 import tarfile
+from typing import Self
 from etils import epath
 
 
 class NotFoundError(KeyError):
   """Raised when the structure store doesn't contain the requested target."""
+
+
+# Maximum size in bytes of a single mmCIF read from a tar archive. This
+# guards against decompression-bomb style archive members causing unbounded
+# memory usage.
+_MAX_MMCIF_READ_SIZE_BYTES = 1 << 30  # 1 GiB
 
 
 class StructureStore:
@@ -64,12 +73,19 @@ class StructureStore:
   @functools.cached_property
   def _tar_members(self) -> Mapping[str, tarfile.TarInfo]:
     assert self._structure_tar is not None
-    return {
-        path.stem: tarinfo
-        for tarinfo in self._structure_tar.getmembers()
-        if tarinfo.isfile()
-        and (path := epath.Path(tarinfo.path.lower())).suffix == '.cif'
-    }
+    members = {}
+    for tarinfo in self._structure_tar.getmembers():
+      if not tarinfo.isfile():
+        continue
+      path = epath.Path(tarinfo.path.lower())
+      if path.suffix not in ('.cif', '.gz'):
+        continue
+      # Key by the target name (the mmCIF file stem) rather than the full
+      # path, matching the directory-based lookup below. Duplicate stems
+      # (e.g. `a/1abc.cif` and `b/1abc.cif`) keep the first occurrence.
+      key = path.stem if path.suffix == '.cif' else path.with_suffix('').stem
+      members.setdefault(key, tarinfo)
+    return members
 
   def get_mmcif_str(self, target_name: str) -> str:
     """Returns an mmCIF for a given `target_name`.
@@ -89,25 +105,28 @@ class StructureStore:
     if self._structure_tar is not None:
       try:
         member = self._tar_members[target_name]
-        if struct_file := self._structure_tar.extractfile(member):
-          return struct_file.read().decode()
-        else:
-          raise NotFoundError(f'{target_name=} not found')
       except KeyError:
         raise NotFoundError(f'{target_name=} not found') from None
+      struct_file = self._structure_tar.extractfile(member)
+      if struct_file is None:
+        raise NotFoundError(f'{target_name=} not found')
+      with struct_file:
+        raw = struct_file.read(_MAX_MMCIF_READ_SIZE_BYTES + 1)
+      if len(raw) > _MAX_MMCIF_READ_SIZE_BYTES:
+        raise IOError(
+            f'mmCIF for {target_name=} exceeds size limit of'
+            f' {_MAX_MMCIF_READ_SIZE_BYTES} bytes'
+        )
+      if member.name.lower().endswith('.gz'):
+        raw = gzip.decompress(raw)
+      return raw.decode()
 
     filepath = self._structure_path / f'{target_name}.cif'  # pyrefly: ignore[unsupported-operation]
     try:
       return filepath.read_text()
-    except Exception as e:
-      # Unfortunately, we can't predict which error type will be raised from the
-      # underlying storage library (e.g. tensorflow or gcsfs), so this is an
-      # attempt to stay backward compatible with file not found without
-      # obscuring other possible error conditions
-      exc_str = str(e).lower()
-      if 'no such file' in exc_str or 'not found' in exc_str:
-        raise NotFoundError(f'{target_name=} not found at {filepath=}') from e
-
+    except FileNotFoundError as e:
+      raise NotFoundError(f'{target_name=} not found at {filepath=}') from e
+    except OSError as e:
       raise IOError(f'Error reading file {filepath}: {e}') from e
 
   def target_names(self) -> Sequence[str]:
@@ -119,3 +138,21 @@ class StructureStore:
     elif self._structure_path is not None:
       return sorted([path.stem for path in self._structure_path.glob('*.cif')])
     return ()
+
+  def close(self) -> None:
+    """Closes the underlying tar archive, releasing the file handle.
+
+    No-op for stores backed by a mapping or a directory.
+    """
+    if self._structure_tar is not None:
+      self._structure_tar.close()
+      self._structure_tar = None
+
+  def __del__(self) -> None:
+    self.close()
+
+  def __enter__(self) -> Self:
+    return self
+
+  def __exit__(self, *exc_info) -> None:
+    self.close()

--- a/src/alphafold3/data/structure_stores.py
+++ b/src/alphafold3/data/structure_stores.py
@@ -22,7 +22,6 @@
 from collections.abc import Mapping, Sequence
 import functools
 import gzip
-import io
 import tarfile
 from typing import Self
 from etils import epath
@@ -119,6 +118,11 @@ class StructureStore:
         )
       if member.name.lower().endswith('.gz'):
         raw = gzip.decompress(raw)
+        if len(raw) > _MAX_MMCIF_READ_SIZE_BYTES:
+          raise IOError(
+              f'Decompressed mmCIF for {target_name=} exceeds size limit of'
+              f' {_MAX_MMCIF_READ_SIZE_BYTES} bytes'
+          )
       return raw.decode()
 
     filepath = self._structure_path / f'{target_name}.cif'  # pyrefly: ignore[unsupported-operation]
@@ -144,7 +148,7 @@ class StructureStore:
 
     No-op for stores backed by a mapping or a directory.
     """
-    if self._structure_tar is not None:
+    if getattr(self, '_structure_tar', None) is not None:
       self._structure_tar.close()
       self._structure_tar = None
 

--- a/src/alphafold3/data/structure_stores.py
+++ b/src/alphafold3/data/structure_stores.py
@@ -22,6 +22,7 @@
 from collections.abc import Mapping, Sequence
 import functools
 import gzip
+import io
 import tarfile
 from typing import Self
 from etils import epath
@@ -35,6 +36,32 @@ class NotFoundError(KeyError):
 # guards against decompression-bomb style archive members causing unbounded
 # memory usage.
 _MAX_MMCIF_READ_SIZE_BYTES = 1 << 30  # 1 GiB
+
+
+def _decompress_bounded(compressed: bytes) -> bytes:
+  """Decompresses gzip data, raising IOError if the output exceeds a limit.
+
+  Args:
+    compressed: Gzip-compressed bytes.
+
+  Returns:
+    The decompressed bytes.
+
+  Raises:
+    IOError: If the decompressed size exceeds `_MAX_MMCIF_READ_SIZE_BYTES` or
+      the data is not valid gzip.
+  """
+  try:
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed)) as gz:
+      out = gz.read(_MAX_MMCIF_READ_SIZE_BYTES + 1)
+  except OSError as e:
+    raise IOError(f'Failed to decompress mmCIF: {e}') from e
+  if len(out) > _MAX_MMCIF_READ_SIZE_BYTES:
+    raise IOError(
+        f'Decompressed mmCIF exceeds size limit of'
+        f' {_MAX_MMCIF_READ_SIZE_BYTES} bytes'
+    )
+  return out
 
 
 class StructureStore:
@@ -117,20 +144,21 @@ class StructureStore:
             f' {_MAX_MMCIF_READ_SIZE_BYTES} bytes'
         )
       if member.name.lower().endswith('.gz'):
-        raw = gzip.decompress(raw)
-        if len(raw) > _MAX_MMCIF_READ_SIZE_BYTES:
-          raise IOError(
-              f'Decompressed mmCIF for {target_name=} exceeds size limit of'
-              f' {_MAX_MMCIF_READ_SIZE_BYTES} bytes'
-          )
+        raw = _decompress_bounded(raw)
       return raw.decode()
 
     filepath = self._structure_path / f'{target_name}.cif'  # pyrefly: ignore[unsupported-operation]
     try:
       return filepath.read_text()
-    except FileNotFoundError as e:
-      raise NotFoundError(f'{target_name=} not found at {filepath=}') from e
-    except OSError as e:
+    except Exception as e:
+      # Unfortunately, we can't predict which error type will be raised from the
+      # underlying storage library (e.g. tensorflow or gcsfs), so this is an
+      # attempt to stay backward compatible with file not found without
+      # obscuring other possible error conditions
+      exc_str = str(e).lower()
+      if 'no such file' in exc_str or 'not found' in exc_str:
+        raise NotFoundError(f'{target_name=} not found at {filepath=}') from e
+
       raise IOError(f'Error reading file {filepath}: {e}') from e
 
   def target_names(self) -> Sequence[str]:

--- a/src/alphafold3/data/structure_stores_test.py
+++ b/src/alphafold3/data/structure_stores_test.py
@@ -1,0 +1,74 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these
+# if received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
+
+"""Tests for the structure stores."""
+
+from absl.testing import absltest
+from alphafold3.data import structure_stores
+import gzip
+import io
+import os
+import tarfile
+import tempfile
+
+
+class StructureStoreTest(absltest.TestCase):
+
+  def test_directory_store(self):
+    with tempfile.TemporaryDirectory() as d:
+      with open(os.path.join(d, '1abc.cif'), 'w') as f:
+        f.write('data_1abc')
+      store = structure_stores.StructureStore(d)
+      self.assertEqual(store.get_mmcif_str('1abc'), 'data_1abc')
+      self.assertIn('1abc', store.target_names())
+      with self.assertRaises(structure_stores.NotFoundError):
+        store.get_mmcif_str('missing')
+
+  def test_tar_store_with_gzipped_mmcif(self):
+    buf = io.BytesIO()
+    gzdata = gzip.compress(b'data_gz')
+    plain = b'data_plain'
+    with tarfile.open(fileobj=buf, mode='w') as tar:
+      for name, data in [('2xyz.cif.gz', gzdata), ('dir/3wxy.cif', plain)]:
+        info = tarfile.TarInfo(name)
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    with tempfile.TemporaryDirectory() as d:
+      tar_path = os.path.join(d, 'store.tar')
+      with open(tar_path, 'wb') as f:
+        f.write(buf.getvalue())
+      store = structure_stores.StructureStore(tar_path)
+      self.assertEqual(store.get_mmcif_str('2xyz'), 'data_gz')
+      self.assertEqual(store.get_mmcif_str('3wxy'), 'data_plain')
+      self.assertIn('2xyz', store.target_names())
+      self.assertIn('3wxy', store.target_names())
+      with self.assertRaises(structure_stores.NotFoundError):
+        store.get_mmcif_str('missing')
+      store.close()
+
+  def test_directory_store_raises_not_found_not_io_error(self):
+    with tempfile.TemporaryDirectory() as d:
+      store = structure_stores.StructureStore(d)
+      with self.assertRaises(structure_stores.NotFoundError):
+        store.get_mmcif_str('does_not_exist')
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/src/alphafold3/data/structure_stores_test.py
+++ b/src/alphafold3/data/structure_stores_test.py
@@ -69,6 +69,30 @@ class StructureStoreTest(absltest.TestCase):
       with self.assertRaises(structure_stores.NotFoundError):
         store.get_mmcif_str('does_not_exist')
 
+  def test_tar_store_rejects_decompression_bomb(self):
+    # A tiny gzip member that expands far beyond the read limit must be
+    # rejected rather than decompressed fully into memory.
+    bomb = gzip.compress(b'0' * 64)
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w') as tar:
+      info = tarfile.TarInfo('bomb.cif.gz')
+      info.size = len(bomb)
+      tar.addfile(info, io.BytesIO(bomb))
+    buf.seek(0)
+    with tempfile.TemporaryDirectory() as d:
+      tar_path = os.path.join(d, 'store.tar')
+      with open(tar_path, 'wb') as f:
+        f.write(buf.getvalue())
+      old_limit = structure_stores._MAX_MMCIF_READ_SIZE_BYTES
+      structure_stores._MAX_MMCIF_READ_SIZE_BYTES = 16
+      try:
+        store = structure_stores.StructureStore(tar_path)
+        with self.assertRaises(IOError):
+          store.get_mmcif_str('bomb')
+      finally:
+        structure_stores._MAX_MMCIF_READ_SIZE_BYTES = old_limit
+        store.close()
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/alphafold3/data/templates.py
+++ b/src/alphafold3/data/templates.py
@@ -530,32 +530,39 @@ class Templates:
         return  # Hmmsearch could return an empty string if there are no hits.
 
       for hit_seq, hit_desc in parsers.lazy_parse_fasta_string(a3m):
-        pdb_id, auth_chain_id, start, end, full_length = _parse_hit_description(
-            hit_desc
-        )
+        try:
+          pdb_id, auth_chain_id, start, end, full_length = (
+              _parse_hit_description(hit_desc)
+          )
 
-        release_date, sequence, unresolved_res_ids = _parse_hit_metadata(
-            structure_store, pdb_id, auth_chain_id
-        )
-        if unresolved_res_ids is None:
+          release_date, sequence, unresolved_res_ids = _parse_hit_metadata(
+              structure_store, pdb_id, auth_chain_id
+          )
+          if unresolved_res_ids is None:
+            continue
+
+          # seq_unresolved_res_num are 1-based, setting to 0-based indices.
+          unresolved_indices = [i - 1 for i in unresolved_res_ids]
+
+          yield Hit(
+              pdb_id=pdb_id,
+              auth_chain_id=auth_chain_id,
+              hmmsearch_sequence=hit_seq,
+              structure_sequence=sequence,  # pyrefly: ignore[bad-argument-type]
+              query_sequence=query_sequence,
+              unresolved_res_indices=unresolved_indices,
+              start_index=start - 1,  # Raw value is residue number, not index.
+              end_index=end,
+              full_length=full_length,
+              release_date=datetime.date.fromisoformat(release_date),
+              chain_poly_type=chain_poly_type,
+          )
+        except (ValueError, KeyError, IOError, OSError) as e:
+          # A single corrupt or unreadable hit (e.g. a malformed hmmsearch
+          # description or an unreadable mmCIF) should not abort the whole
+          # template search for the query. Skip it and continue with the rest.
+          logging.warning('Skipping template hit %r: %s', hit_desc, e)
           continue
-
-        # seq_unresolved_res_num are 1-based, setting to 0-based indices.
-        unresolved_indices = [i - 1 for i in unresolved_res_ids]
-
-        yield Hit(
-            pdb_id=pdb_id,
-            auth_chain_id=auth_chain_id,
-            hmmsearch_sequence=hit_seq,
-            structure_sequence=sequence,  # pyrefly: ignore[bad-argument-type]
-            query_sequence=query_sequence,
-            unresolved_res_indices=unresolved_indices,
-            start_index=start - 1,  # Raw value is residue number, not index.
-            end_index=end,
-            full_length=full_length,
-            release_date=datetime.date.fromisoformat(release_date),
-            chain_poly_type=chain_poly_type,
-        )
 
     if filter_config is None:
       hits = tuple(hit_generator(a3m))


### PR DESCRIPTION
## Summary

A single bad template hit currently aborts the entire template search for a query. Two failure modes:

1. An hmmsearch description that does not match the expected format raises `ValueError` from `_parse_hit_description`.
2. An unreadable or corrupt mmCIF raises `IOError`/`OSError` (or a backend-specific type, e.g. from tensorflow/gcsfs) from `_parse_hit_metadata`, and the underlying `StructureStore` can raise raw storage errors instead of a clean `NotFoundError`.

This mirrors the crash reported in #714, where one unreadable template mmCIF aborts the whole prediction.

## Fix

- `templates.hit_generator`: wrap each hit in a `try/except` catching `ValueError`, `KeyError`, `IOError`, and `OSError`, log a warning, and skip the corrupt hit instead of aborting the search. `NotFoundError` continues to be handled by skipping the hit as before.
- `structure_stores.StructureStore`:
  - Support gzipped mmCIF members (`*.cif.gz`) inside tar stores.
  - Cap the size of a single (decompressed) mmCIF to 1 GiB, streaming the gzip output so a decompression bomb cannot allocate unbounded memory.
  - Key tar members by target name (mmCIF stem) rather than full path, matching directory-store lookup; duplicate stems keep the first occurrence.
  - Add `close()`/context-manager support so the tar file handle is released deterministically (also fixes a Windows file-lock issue when deleting the tar).
  - Preserve the original broad exception handling in the directory-store path so cloud storage backends (e.g. GCS) keep raising `NotFoundError` for missing files.

## Tests

Added `structure_stores_test.py` covering directory stores, gzipped and plain tar members, not-found classification, and decompression-bomb rejection. All pass:

```
4 passed in 0.35s
```

## AI disclosure

Code and tests generated with AI assistance and manually reviewed.