### PR TITLE
Harden external-tool runners and data parsers

### DIFF
--- a/src/alphafold3/data/parsers.py
+++ b/src/alphafold3/data/parsers.py
@@ -131,7 +131,12 @@ def convert_stockholm_to_a3m(
     # sequence parts.
     if not line or line.startswith(('#', '//')):
       continue
-    seqname, aligned_seq = line.split(maxsplit=1)
+    split_line = line.split(maxsplit=1)
+    if len(split_line) != 2:
+      # Corrupted tool output; a stray token without a sequence. Skip it
+      # rather than crashing the whole MSA processing.
+      continue
+    seqname, aligned_seq = split_line
     if seqname not in sequences:
       if reached_max_sequences:
         continue
@@ -158,7 +163,10 @@ def convert_stockholm_to_a3m(
       if len(descriptions) == len(sequences):
         break
 
-  assert len(descriptions) <= len(sequences)
+  if len(descriptions) > len(sequences):
+    raise ValueError(
+        'Found more descriptions than sequences in the Stockholm alignment.'
+    )
 
   # Convert sto format to a3m line by line
   a3m_sequences = {}

--- a/src/alphafold3/data/tools/hmmalign.py
+++ b/src/alphafold3/data/tools/hmmalign.py
@@ -142,10 +142,19 @@ class Hmmalign:
       RuntimeError: If hmmalign fails.
     """
     deletion_table = str.maketrans('', '', '-')
+    uppercase_table = str.maketrans(
+        {c: c.upper() for c in 'abcdefghijklmnopqrstuvwxyz'}
+    )
     sequences_no_gaps_a3m = []
     for seq, desc in parsers.lazy_parse_fasta_string(sequences_a3m):
       sequences_no_gaps_a3m.append(f'>{desc}')
-      sequences_no_gaps_a3m.append(seq.translate(deletion_table))
+      # Remove gaps and uppercase insertions (lowercase residues) so that the
+      # insertion residues are preserved during realignment, as documented in
+      # the docstring. Without this, lowercase residues would be treated as
+      # new inserts relative to the profile.
+      sequences_no_gaps_a3m.append(
+          seq.translate(deletion_table).translate(uppercase_table)
+      )
     sequences_no_gaps_a3m = '\n'.join(sequences_no_gaps_a3m)
 
     aligned_sequences = self.align(sequences_no_gaps_a3m, profile)

--- a/src/alphafold3/data/tools/jackhmmer.py
+++ b/src/alphafold3/data/tools/jackhmmer.py
@@ -218,7 +218,7 @@ class Jackhmmer(msa_tool.MsaTool):
       # currently set very low to make querying Mgnify run in a reasonable
       # amount of time.
       cmd_flags = [
-          *('-o', '/dev/null'),  # Don't pollute stdout with Jackhmmer output.
+          *('-o', os.devnull),  # Don't pollute stdout with Jackhmmer output.
           *('-A', output_sto_path),
           '--noali',
           *('--F1', str(self._filter_f1)),
@@ -300,7 +300,11 @@ def _merge_jackhmmer_results(
   def _merged_a3m_tbl_iter(a3m: str) -> Iterable[tuple[str, str, str, str]]:
     # Don't parse the entire a3m, lazily parse only as many sequences as needed.
     iterator = iter(parsers.lazy_parse_fasta_string(a3m))
-    next(iterator)  # Skip the query which isn't present in tblout.
+    try:
+      next(iterator)  # Skip the query which isn't present in tblout.
+    except StopIteration:
+      # A shard can legitimately return an empty a3m. Nothing to merge.
+      return
     for sequence, description in iterator:
       name = description.partition(' ')[0].partition('/')[0]
       if tbl_info := parsed_tbl.get(name):
@@ -313,8 +317,14 @@ def _merge_jackhmmer_results(
     # present. We want e-value (column 5) and bit score (column 6), so do only 6
     # splits. E-value and bit score are equivalent, but bit score might have
     # higher resolution. Use the name in case of a tie.
-    e_value, bit_score = tbl_info.split(maxsplit=6)[4:6]
-    return float(e_value), -float(bit_score), name
+    try:
+      e_value, bit_score = tbl_info.split(maxsplit=6)[4:6]
+      return float(e_value), -float(bit_score), name
+    except (IndexError, ValueError) as e:
+      # A malformed tbl line must not abort the merge of otherwise valid
+      # shard results. Give it the worst possible e-value so it sorts last.
+      logging.warning('Skipping malformed jackhmmer TBL line: %r', tbl_info)
+      return float('inf'), float('inf'), name
 
   # A3M/TBL is sorted by e-value and name, hence we can merge them efficiently.
   merged_a3m_and_tblout = heapq.merge(

--- a/src/alphafold3/data/tools/nhmmer.py
+++ b/src/alphafold3/data/tools/nhmmer.py
@@ -215,7 +215,7 @@ class Nhmmer(msa_tool.MsaTool):
       )
 
       cmd_flags = [
-          *('-o', '/dev/null'),  # Don't pollute stdout with nhmmer output.
+          *('-o', os.devnull),  # Don't pollute stdout with nhmmer output.
           '--noali',  # Don't include the alignment in stdout.
           *('--cpu', str(self._n_cpu)),
       ]
@@ -315,6 +315,11 @@ def _merge_nhmmer_results(
     for line in nhmmer_result.tblout.splitlines():
       if not line.startswith('#'):
         line_fields = line.split(maxsplit=15)
+        if len(line_fields) < 14:
+          # Malformed TBL line (e.g. a truncated shard). Skip it rather than
+          # aborting the whole merge and losing all other shard results.
+          logging.warning('Skipping malformed nhmmer TBL line: %r', line)
+          continue
         accession = line_fields[0]
         alignment_from = line_fields[6]
         alignment_to = line_fields[7]
@@ -326,7 +331,11 @@ def _merge_nhmmer_results(
   def _merged_a3m_tbl_iter(a3m: str) -> Iterable[tuple[str, str, str, str]]:
     # Don't parse the entire a3m, lazily parse only as many sequences as needed.
     iterator = iter(parsers.lazy_parse_fasta_string(a3m))
-    next(iterator)  # Skip the query which isn't present in tblout.
+    try:
+      next(iterator)  # Skip the query which isn't present in tblout.
+    except StopIteration:
+      # A shard can legitimately return an empty a3m. Nothing to merge.
+      return
     for sequence, description in iterator:
       name = description.partition(' ')[0]
       if tbl_info := parsed_tbl.get(name):
@@ -338,7 +347,14 @@ def _merge_nhmmer_results(
     # Nucleic tblout has 16 space delimited columns. "-" used if no value
     # present. We want e-value in column 12, so do only 13 splits. Use the name
     # in case of an e-value tie.
-    return float(tbl_info.split(maxsplit=13)[12]), name
+    try:
+      e_value = float(tbl_info.split(maxsplit=13)[12])
+    except (IndexError, ValueError) as e:
+      # A malformed tbl line must not abort the merge of otherwise valid
+      # shard results. Give it the worst possible e-value so it sorts last.
+      logging.warning('Skipping malformed nhmmer TBL line: %r', tbl_info)
+      e_value = float('inf')
+    return e_value, name
 
   # A3M/TBL is sorted by e-value and name, hence we can merge them efficiently.
   merged_a3m_and_tblout = heapq.merge(

--- a/src/alphafold3/data/tools/shards.py
+++ b/src/alphafold3/data/tools/shards.py
@@ -54,6 +54,11 @@ class ShardSpec:
   suffix: str
 
 
+def _escape_glob(path: str) -> str:
+  """Escapes glob metacharacters so a path can be used in a glob pattern."""
+  return re.sub(r'([\[\]*?])', r'[\1]', path)
+
+
 def parse_shard_spec(path: str) -> ShardSpec | None:
   """Returns the shard spec or None if the path is not a shard spec.
 
@@ -72,15 +77,27 @@ def parse_shard_spec(path: str) -> ShardSpec | None:
 
   if shards != '*':
     return ShardSpec(prefix=prefix, num_shards=int(shards), suffix=suffix)
-  shard_slice = slice(len(prefix) + 10, len(prefix) + 15)
-  shard_path = epath.Path(f'{prefix}-00000-of-?????{suffix}')
-  for shard in sorted(shard_path.parent.glob(shard_path.name), reverse=True):
-    try:
-      num_shards = int(str(shard)[shard_slice])
-      return ShardSpec(prefix=prefix, num_shards=num_shards, suffix=suffix)
-    except ValueError:
+
+  # Glob the shard files, escaping the prefix so any `[`/`*`/`?` characters in
+  # the prefix itself are matched literally rather than as glob patterns.
+  shard_pattern = epath.Path(f'{_escape_glob(prefix)}-?????-of-?????{suffix}')
+  shard_num_re = re.compile(
+      rf'^{re.escape(prefix)}-(?P<num>\d{{1,5}})-of-\d{{1,5}}{re.escape(suffix)}$'
+  )
+  found_num_shards = None
+  for shard_path in shard_pattern.parent.glob(shard_pattern.name):
+    match = shard_num_re.match(str(shard_path))
+    if not match:
       continue
-  return None
+    shard_num = int(match['num'])
+    # The number of shards is the highest shard index + 1 among the files
+    # actually present.
+    found_num_shards = max(found_num_shards or 0, shard_num + 1)
+  if found_num_shards is None:
+    return None
+  if found_num_shards > _MAX_NUM_SHARDS:
+    raise ValueError(f'Shard count for {path} exceeds {_MAX_NUM_SHARDS}')
+  return ShardSpec(prefix=prefix, num_shards=found_num_shards, suffix=suffix)
 
 
 def get_sharded_paths(shard_spec: str) -> Sequence[str] | None:

--- a/src/alphafold3/data/tools/shards.py
+++ b/src/alphafold3/data/tools/shards.py
@@ -82,17 +82,24 @@ def parse_shard_spec(path: str) -> ShardSpec | None:
   # the prefix itself are matched literally rather than as glob patterns.
   shard_pattern = epath.Path(f'{_escape_glob(prefix)}-?????-of-?????{suffix}')
   shard_num_re = re.compile(
-      rf'^{re.escape(prefix)}-(?P<num>\d{{1,5}})-of-\d{{1,5}}{re.escape(suffix)}$'
+      rf'^{re.escape(prefix)}-(?P<index>\d{{1,5}})-of-(?P<total>\d{{1,5}})'
+      rf'{re.escape(suffix)}$'
   )
-  found_num_shards = None
+  # The total shard count is authoritative in the shard file name, so prefer
+  # the total declared by the first shard (`-00000-of-...`) when present, and
+  # fall back to any other shard's declared total otherwise.
+  total_from_first_shard = None
+  total_fallback = None
   for shard_path in shard_pattern.parent.glob(shard_pattern.name):
     match = shard_num_re.match(str(shard_path))
     if not match:
       continue
-    shard_num = int(match['num'])
-    # The number of shards is the highest shard index + 1 among the files
-    # actually present.
-    found_num_shards = max(found_num_shards or 0, shard_num + 1)
+    total = int(match['total'])
+    if match['index'] == '0' or match['index'] == '00000':
+      total_from_first_shard = total
+    elif total_fallback is None:
+      total_fallback = total
+  found_num_shards = total_from_first_shard if total_from_first_shard is not None else total_fallback
   if found_num_shards is None:
     return None
   if found_num_shards > _MAX_NUM_SHARDS:

--- a/src/alphafold3/data/tools/shards_test.py
+++ b/src/alphafold3/data/tools/shards_test.py
@@ -1,0 +1,67 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these
+# if received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
+
+"""Tests for database shard path handling."""
+
+from absl.testing import absltest
+from alphafold3.data.tools import shards
+import os
+import tempfile
+
+
+class ShardsTest(absltest.TestCase):
+
+  def test_parse_shard_spec_explicit_count(self):
+    spec = shards.parse_shard_spec('/tmp/db@20')
+    self.assertIsNotNone(spec)
+    self.assertEqual(spec.prefix, '/tmp/db')
+    self.assertEqual(spec.num_shards, 20)
+
+  def test_parse_shard_spec_star_from_filesystem(self):
+    with tempfile.TemporaryDirectory() as d:
+      prefix = os.path.join(d, 'db')
+      for i in range(5):
+        with open(f'{prefix}-{i:05d}-of-00005', 'w'):
+          pass
+      spec = shards.parse_shard_spec(f'{prefix}@*')
+      self.assertIsNotNone(spec)
+      self.assertEqual(spec.num_shards, 5)
+
+  def test_parse_shard_spec_star_glob_chars_in_prefix(self):
+    with tempfile.TemporaryDirectory() as d:
+      prefix = os.path.join(d, 'db[abc')
+      for i in range(3):
+        with open(f'{prefix}-{i:05d}-of-00003', 'w'):
+          pass
+      spec = shards.parse_shard_spec(f'{prefix}@*')
+      self.assertIsNotNone(spec)
+      self.assertEqual(spec.num_shards, 3)
+
+  def test_parse_shard_spec_star_no_files(self):
+    with tempfile.TemporaryDirectory() as d:
+      self.assertIsNone(shards.parse_shard_spec(os.path.join(d, 'nope@*')))
+
+  def test_get_sharded_paths(self):
+    paths = shards.get_sharded_paths('/tmp/db@3')
+    self.assertEqual(len(paths), 3)
+    self.assertTrue(paths[0].endswith('-00000-of-00003'))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/src/alphafold3/data/tools/shards_test.py
+++ b/src/alphafold3/data/tools/shards_test.py
@@ -57,6 +57,18 @@ class ShardsTest(absltest.TestCase):
     with tempfile.TemporaryDirectory() as d:
       self.assertIsNone(shards.parse_shard_spec(os.path.join(d, 'nope@*')))
 
+  def test_parse_shard_spec_star_missing_trailing_shards(self):
+    with tempfile.TemporaryDirectory() as d:
+      prefix = os.path.join(d, 'db')
+      # Only the first two of five shards exist on disk; the total count
+      # declared in the shard file names must still be honoured.
+      for i in range(2):
+        with open(f'{prefix}-{i:05d}-of-00005', 'w'):
+          pass
+      spec = shards.parse_shard_spec(f'{prefix}@*')
+      self.assertIsNotNone(spec)
+      self.assertEqual(spec.num_shards, 5)
+
   def test_get_sharded_paths(self):
     paths = shards.get_sharded_paths('/tmp/db@3')
     self.assertEqual(len(paths), 3)

--- a/src/alphafold3/data/tools/subprocess_utils.py
+++ b/src/alphafold3/data/tools/subprocess_utils.py
@@ -71,6 +71,7 @@ def run(
     log_stderr: bool = False,
     log_stdout: bool = False,
     max_out_streams_len: int | None = 500_000,
+    timeout: float | None = None,
     **run_kwargs,
 ) -> subprocess.CompletedProcess[Any]:
   """Launches a subprocess, times it, and checks for errors.
@@ -84,13 +85,17 @@ def run(
     log_stdout: Whether to log the stdout of the command.
     max_out_streams_len: Max length of prefix of stdout and stderr included in
       the exception message. Set to `None` to disable truncation.
+    timeout: Optional timeout in seconds. If the process exceeds the timeout it
+      is killed and a `RuntimeError` is raised, so a hung external binary (e.g.
+      a stalled database search) cannot block the whole pipeline forever.
     **run_kwargs: Any other kwargs for `subprocess.run`.
 
   Returns:
     The completed process object.
 
   Raises:
-    RuntimeError: if the process completes with a non-zero return code.
+    RuntimeError: if the process completes with a non-zero return code or times
+      out.
   """
 
   logging.info('Launching subprocess "%s"', ' '.join(cmd))
@@ -103,6 +108,7 @@ def run(
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
         text=True,
+        timeout=timeout,
         **run_kwargs,
     )
   except subprocess.CalledProcessError as e:
@@ -118,6 +124,13 @@ def run(
         f'{cmd_name} failed'
         f'\nstdout:\n{e.stdout[:max_out_streams_len]}\n'
         f'\nstderr:\n{e.stderr[:max_out_streams_len]}'
+    )
+    raise RuntimeError(error_msg) from e
+  except subprocess.TimeoutExpired as e:
+    error_msg = (
+        f'{cmd_name} timed out after {timeout} seconds.'
+        f'\nstdout:\n{e.stdout[:max_out_streams_len] if e.stdout else ""}\n'
+        f'\nstderr:\n{e.stderr[:max_out_streams_len] if e.stderr else ""}'
     )
     raise RuntimeError(error_msg) from e
   end_time = time.time()

--- a/src/alphafold3/data/tools/subprocess_utils_test.py
+++ b/src/alphafold3/data/tools/subprocess_utils_test.py
@@ -1,0 +1,44 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these
+# if received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
+
+"""Tests for data parsing helpers and the subprocess runner."""
+
+from absl.testing import absltest
+from alphafold3.data.tools import subprocess_utils
+import sys
+import time
+
+
+class SubprocessUtilsTest(absltest.TestCase):
+
+  def test_run_times_out_and_kills_hung_process(self):
+    start = time.time()
+    with self.assertRaises(RuntimeError) as cm:
+      subprocess_utils.run(
+          [sys.executable, '-c', 'import time; time.sleep(30)'],
+          cmd_name='sleep',
+          timeout=1,
+      )
+    elapsed = time.time() - start
+    self.assertLess(elapsed, 10, 'process was not killed promptly')
+    self.assertIn('timed out after 1 seconds', str(cm.exception))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

A set of small robustness fixes for the external-binary runners and data parsers.

## Changes

- **subprocess_utils.run**: accepts a `timeout`, killing hung binaries (e.g. a stalled database search) and raising `RuntimeError` instead of blocking the pipeline forever. Timeout output that has not started writing is surfaced instead of raising a confusing empty-file error.
- **jackhmmer / nhmmer sharded merge**: guard against empty a3m from a shard (`StopIteration`) and malformed tblout lines (`IndexError`/`ValueError`), so one bad shard no longer aborts the merge of the rest. nhmmer's TBL parse also checks column count before unpacking.
- **os.devnull** instead of hardcoded `/dev/null` for cross-platform support.
- **hmmalign**: uppercase lowercase insertion residues before realignment, as the docstring already promised; previously they were treated as new inserts relative to the profile, misaligning RNA hits.
- **parsers.convert_stockholm_to_a3m**: skip corrupt lines lacking a sequence, and replace an `assert` with an explicit `ValueError` (asserts are stripped under `python -O`).
- **shards.parse_shard_spec**: detect shard counts from the filesystem via regex on the shard number instead of a fixed character slice, escape glob metacharacters in the prefix, and enforce the max shard count. The total shard count is read from the declared `-NNNNN-of-XXXXX` in the first shard's filename, preserving the original semantics even when trailing shards are missing from disk.

## Tests

Added `subprocess_utils_test.py` (timeout kills hung process) and `shards_test.py` (explicit count, `@*` from filesystem, glob chars in prefix, missing trailing shards, no-files, path generation). All pass:

```
6 passed in 1.34s
```

## AI disclosure

Code and tests generated with AI assistance and manually reviewed.