### PR TITLE
Validate template query indices against the sequence length

### DIFF
--- a/src/alphafold3/common/folding_input.py
+++ b/src/alphafold3/common/folding_input.py
@@ -234,6 +234,18 @@ class ProteinChain:
       raise ValueError(
           f'Protein ptms must not contain the "CCD_" prefix, got {ptms}'
       )
+    for template in templates or ():
+      for query_index, template_index in template.query_to_template_map.items():
+        if not 0 <= query_index < len(sequence):
+          raise ValueError(
+              f'Invalid template query index: {query_index}, must be in the'
+              f' range [0, {len(sequence)}) for a sequence of length'
+              f' {len(sequence)}.'
+          )
+        if template_index < 0:
+          raise ValueError(
+              f'Invalid template index: {template_index}, must not be negative.'
+          )
     # Use hashable containers for ptms and templates.
     self._id = id
     self._sequence = sequence


### PR DESCRIPTION
## What happens today

A template whose `queryIndices` fall outside the sequence is accepted without
complaint. On a 76-residue chain:

| input | result |
| --- | --- |
| `queryIndices: [99999]` | `IndexError: index 99999 is out of bounds for axis 0 with size 76`, raised from numpy during featurisation |
| `queryIndices: [-5]` | **no error at all**, the chain is folded and a normal-looking structure is written |
| `templateIndices: [-5]` | same, wraps silently |

The negative case is the one that matters. Python wraps the index, so the model
folds against a template alignment the user never specified, the run completes,
and nothing indicates anything went wrong.

## Cause

`ProteinChain.__init__` validates PTM positions against the sequence length:

```python
if any(not 0 < mod[1] <= len(sequence) for mod in ptms):
  raise ValueError(f'Invalid protein modification index: {ptms}')
```

but performs no equivalent check on the template `query_to_template_map`, whose
keys are indices into that same sequence.

## Change

Reject out-of-range query indices and negative template indices at parse time,
in the same constructor, directly below the PTM check.

## Not covered

`templateIndices` exceeding the *template's* own length still produce the bare
`IndexError`. Catching that requires parsing the template mmCIF, which does not
happen at construction time, so it is left alone here.

## Verified

Against the real pipeline, using an AlphaFold 3 output mmCIF as the template:

| case | before | after |
| --- | --- | --- |
| valid (control) | accepted, folds | accepted, folds |
| query past end | accepted | `ValueError: ... must be in the range [0, 76)` |
| query negative | accepted | `ValueError: ... must be in the range [0, 76)` |
| template negative | accepted | `ValueError: ... must not be negative` |

Regression control: a valid template input still folds end to end, exit 0,
structure written.