### PR TITLE
Report a clear error for GPUs without a numeric compute capability

### DIFF
--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -956,9 +956,21 @@ def main(_):
     elif _JAX_BACKEND.value == JaxBackend.GPU:
       gpu_devices = jax.local_devices(backend='gpu')
       if gpu_devices:
-        compute_capability = float(
-            gpu_devices[_GPU_DEVICE.value].compute_capability
+        gpu_device = gpu_devices[_GPU_DEVICE.value]
+        raw_compute_capability = getattr(
+            gpu_device, 'compute_capability', None
         )
+        try:
+          compute_capability = float(raw_compute_capability)
+        except (TypeError, ValueError):
+          # Non-NVIDIA GPUs do not report a numeric compute capability. AMD
+          # GPUs, for instance, report an architecture string such as "gfx942".
+          raise ValueError(
+              f'Unsupported GPU: {gpu_device.device_kind} reports compute'
+              f' capability {raw_compute_capability!r}, which is not numeric.'
+              ' AlphaFold 3 currently requires an NVIDIA GPU when'
+              ' --jax_backend=gpu. Use --jax_backend=cpu to run on CPU.'
+          ) from None
         if compute_capability < 6.0:
           raise ValueError(
               'AlphaFold 3 requires at least GPU compute capability 6.0 (see'


### PR DESCRIPTION
## What happens today

`run_alphafold.py` assumes `device.compute_capability` parses as a float. That holds on NVIDIA, where it is a value like `'12.0'`. On other GPUs it does not. An AMD MI300X reports an architecture string, so AlphaFold 3 fails at startup with:

```
ValueError: could not convert string to float: 'gfx942'
```

That message does not name the device, explain the constraint, or suggest anything to do about it.

## The change

Catch the non-numeric case in the existing device check and report something actionable:

```
Unsupported GPU: AMD Instinct MI300X VF reports compute capability 'gfx942',
which is not numeric. AlphaFold 3 currently requires an NVIDIA GPU when
--jax_backend=gpu. Use --jax_backend=cpu to run on CPU.
```

`getattr(..., None)` plus catching `TypeError` also covers devices that do not expose the attribute at all, which is the case the tokamax source notes for Pathways arrays.

No behaviour change on NVIDIA. The value still parses and every existing capability check runs exactly as before.

## Verified

On an MI300X (ROCm 7.2.4, `jax==0.10.2` with `jax-rocm7-plugin==0.10.2`):

- before: `ValueError: could not convert string to float: 'gfx942'`
- after: the message above
- `--jax_backend=cpu` on the same machine folds correctly, ptm 0.83, mean pLDDT 90.20, matching an RTX 5080 CUDA reference for the same input and seed

## Context

This came out of looking at what it would take to run AF3 on AMD GPUs, which was suggested to me to start on. Short version of where that got to:

AF3 itself needs very little. This check, and making the `jax[cuda12]` pin conditional the way `jax-mps` already is. It builds cleanly on ROCm including the C++ extensions, loads weights, and featurises.

The first real blocker is upstream in [tokamax](https://github.com/openxla/tokamax), which assumes a numeric compute capability in four places (`gpu_utils.py` and `precision.py`) and raises the same `ValueError`. With those patched locally, tokamax's fallback machinery works correctly: the Pallas kernels report themselves unsupported on AMD and it falls through, with `gated_linear_unit` and `dot_product_attention(implementation='xla')` both passing.

Past that, inference reaches the model and segfaults inside `jax-rocm7-plugin`. It survives float32, one recycle, one sample, disabled GLU kernels, and every XLA flag I could validate, while the identical build produces a correct structure on CPU. So that part is a ROCm backend issue rather than an AlphaFold one, and I am working on a minimal reproducer to file with AMD.

Happy to write the AMD findings up properly if useful.